### PR TITLE
Fix docker-compose command in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ You still might want to use `docker` and `docker-compose` for running SDK and DB
 
 If this is your first launch, initialize:
 
-`docker-compose up postgres lbrynet --no-start`
+`docker-compose up --no-start postgres lbrynet`
 
 After that, launch the containers:
 


### PR DESCRIPTION
`docker-compose up --no-start 'services'`
instead of
`docker-compose up 'services' --no-start`

The later one will give an error
`ERROR: No such service: --no-start`
