### PR TITLE
Do not authenticate method calls that do not require account identifi…

### DIFF
--- a/app/proxy/handlers.go
+++ b/app/proxy/handlers.go
@@ -40,18 +40,21 @@ func (rh *RequestHandler) Handle(w http.ResponseWriter, r *http.Request) {
 
 	var walletID string
 	if config.AccountsEnabled() {
-		retriever := users.NewWalletService()
-		auth := users.NewAuthenticator(retriever)
-		walletID, err = auth.GetWalletID(r)
+		q, err := NewQuery(body)
+		if err != nil || !methodInList(q.Method(), relaxedMethods) {
+			retriever := users.NewWalletService()
+			auth := users.NewAuthenticator(retriever)
+			walletID, err = auth.GetWalletID(r)
 
-		// TODO: Refactor error response creation
-		if err != nil {
-			response, _ := json.Marshal(NewErrorResponse(err.Error(), ErrAuthFailed))
-			w.Header().Set("Content-Type", "application/json; charset=utf-8")
-			w.WriteHeader(http.StatusOK)
-			w.Write(response)
-			monitor.CaptureRequestError(err, r, w)
-			return
+			// TODO: Refactor error response creation
+			if err != nil {
+				response, _ := json.Marshal(NewErrorResponse(err.Error(), ErrAuthFailed))
+				w.Header().Set("Content-Type", "application/json; charset=utf-8")
+				w.WriteHeader(http.StatusOK)
+				w.Write(response)
+				monitor.CaptureRequestError(err, r, w)
+				return
+			}
 		}
 	}
 	c := rh.ProxyService.NewCaller(walletID)


### PR DESCRIPTION
Lbrytv was authenticating every call whenever auth token header was present, even for methods that did not require it. This fixes it.