### PR TITLE
Set wallet option skip_on_startup to true

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,6 @@ jobs:
     docker:
       - image: lbry/lbrytv-ci:latest
       - image: lbry/lbrynet-tv:latest
-        environment:
-          SDK_LBRYUM_SERVERS: spv1.lbry.com:50001
       - image: postgres:11-alpine
         environment:
           POSTGRES_USER: lbrytv

--- a/internal/lbrynet/lbrynet.go
+++ b/internal/lbrynet/lbrynet.go
@@ -16,7 +16,7 @@ import (
 const accountNamePrefix string = "lbrytv-user-id:"
 const accountNameTemplate string = accountNamePrefix + "%v"
 
-var defaultWalletOpts = ljsonrpc.WalletCreateOpts{SkipOnStartup: false, CreateAccount: true, SingleKey: true}
+var defaultWalletOpts = ljsonrpc.WalletCreateOpts{SkipOnStartup: true, CreateAccount: true, SingleKey: true}
 
 var Logger = monitor.NewModuleLogger("lbrynet")
 


### PR DESCRIPTION
Per @lex this should be passed as true to prevent the wallet from being added to the config.

