### PR TITLE
DB Retry Behavior

### DIFF
--- a/internal/storage/conn.go
+++ b/internal/storage/conn.go
@@ -11,7 +11,7 @@ import (
 	"github.com/volatiletech/sqlboiler/boil"
 )
 
-const maxDBConnectAttempts = 10
+const maxDBConnectAttempts = 7
 
 // Handler implements the app database handler.
 type Handler interface {
@@ -63,14 +63,14 @@ func (c *Connection) Connect() error {
 	dsn := MakeDSN(c.params)
 	c.logger.LogF(monitor.F{"dsn": dsn}).Info("connecting to the DB")
 	var err error
-	var secondsToWait int
 	var db *sqlx.DB
 	for i := 0; i < maxDBConnectAttempts; i++ {
 		db, err = sqlx.Connect(c.dialect, dsn)
 		if err == nil {
 			break
 		}
-		secondsToWait = secondsToWait + i + 1
+		secondsToWait := i + 1
+		c.logger.Log().Warning("Database Connection Err: ", err)
 		c.logger.Log().Warningf("Attempt %d - could not connect to database...retry in %d seconds", i, secondsToWait)
 		time.Sleep(time.Duration(secondsToWait) * time.Second)
 	}

--- a/internal/storage/conn.go
+++ b/internal/storage/conn.go
@@ -70,8 +70,7 @@ func (c *Connection) Connect() error {
 			break
 		}
 		secondsToWait := i + 1
-		c.logger.Log().Warning("Database Connection Err: ", err)
-		c.logger.Log().Warningf("Attempt %d - could not connect to database...retry in %d seconds", i, secondsToWait)
+		c.logger.Log().Warningf("Attempt %d - could not connect to database...retry in %d seconds: %s", i, secondsToWait, err)
 		time.Sleep(time.Duration(secondsToWait) * time.Second)
 	}
 

--- a/internal/storage/conn.go
+++ b/internal/storage/conn.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/lbryio/lbrytv/internal/monitor"
 
@@ -9,6 +10,8 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/volatiletech/sqlboiler/boil"
 )
+
+const maxDBConnectAttempts = 10
 
 // Handler implements the app database handler.
 type Handler interface {
@@ -59,7 +62,19 @@ func InitConn(params ConnParams) *Connection {
 func (c *Connection) Connect() error {
 	dsn := MakeDSN(c.params)
 	c.logger.LogF(monitor.F{"dsn": dsn}).Info("connecting to the DB")
-	db, err := sqlx.Connect(c.dialect, dsn)
+	var err error
+	var secondsToWait int
+	var db *sqlx.DB
+	for i := 0; i < maxDBConnectAttempts; i++ {
+		db, err = sqlx.Connect(c.dialect, dsn)
+		if err == nil {
+			break
+		}
+		secondsToWait = secondsToWait + i + 1
+		c.logger.Log().Warningf("Attempt %d - could not connect to database...retry in %d seconds", i, secondsToWait)
+		time.Sleep(time.Duration(secondsToWait) * time.Second)
+	}
+
 	if err != nil {
 		c.logger.LogF(monitor.F{"dsn": dsn}).Info("DB connection failed")
 		return err


### PR DESCRIPTION
Don't just error on db connections. DBs lose connections, it happens. Retry periodically, with increasing intervals before finally returning an error to connect to the database.

This is also beneficial for our container compositions. If postgres does not startup in time, it will retry.

<img width="902" alt="Screen Shot 2020-01-03 at 9 46 21 PM" src="https://user-images.githubusercontent.com/3402064/71758836-af467080-2e72-11ea-866b-2a7e7b0a1d51.png">


