### PR TITLE
Bugfix/wallet loading

### DIFF
--- a/app/proxy/client_test.go
+++ b/app/proxy/client_test.go
@@ -6,12 +6,50 @@ import (
 	"time"
 
 	"github.com/lbryio/lbrytv/app/router"
+	"github.com/lbryio/lbrytv/util/wallet"
 
 	"github.com/lbryio/lbrytv/internal/lbrynet"
 
 	"github.com/stretchr/testify/require"
 	"github.com/ybbus/jsonrpc"
 )
+
+type MockRPCClient struct {
+	Delay        time.Duration
+	LastRequest  jsonrpc.RPCRequest
+	NextResponse chan *jsonrpc.RPCResponse
+}
+
+func NewMockRPCClient() *MockRPCClient {
+	return &MockRPCClient{
+		NextResponse: make(chan *jsonrpc.RPCResponse, 100),
+	}
+}
+
+func (c MockRPCClient) AddNextResponse(r *jsonrpc.RPCResponse) {
+	c.NextResponse <- r
+}
+
+func (c MockRPCClient) Call(method string, params ...interface{}) (*jsonrpc.RPCResponse, error) {
+	return <-c.NextResponse, nil
+}
+
+func (c *MockRPCClient) CallRaw(request *jsonrpc.RPCRequest) (*jsonrpc.RPCResponse, error) {
+	c.LastRequest = *request
+	return <-c.NextResponse, nil
+}
+
+func (c MockRPCClient) CallFor(out interface{}, method string, params ...interface{}) error {
+	return nil
+}
+
+func (c MockRPCClient) CallBatch(requests jsonrpc.RPCRequests) (jsonrpc.RPCResponses, error) {
+	return nil, nil
+}
+
+func (c MockRPCClient) CallBatchRaw(requests jsonrpc.RPCRequests) (jsonrpc.RPCResponses, error) {
+	return nil, nil
+}
 
 func TestClientCallDoesReloadWallet(t *testing.T) {
 	var (
@@ -36,4 +74,71 @@ func TestClientCallDoesReloadWallet(t *testing.T) {
 	// err = json.Unmarshal(result, response)
 	require.NoError(t, err)
 	require.Nil(t, r.Error)
+}
+
+func TestClientCallDoesNotReloadWalletAfterOtherErrors(t *testing.T) {
+	var (
+		r *jsonrpc.RPCResponse
+	)
+
+	rand.Seed(time.Now().UnixNano())
+	wid := wallet.MakeID(rand.Intn(100))
+
+	mc := NewMockRPCClient()
+	c := &Client{rpcClient: mc}
+	q, _ := NewQuery(newRawRequest(t, "wallet_balance", nil))
+	q.SetWalletID(wid)
+
+	mc.AddNextResponse(&jsonrpc.RPCResponse{
+		JSONRPC: "2.0",
+		Error: &jsonrpc.RPCError{
+			Message: "Couldn't find wallet: //",
+		},
+	})
+	mc.AddNextResponse(&jsonrpc.RPCResponse{
+		JSONRPC: "2.0",
+		Error: &jsonrpc.RPCError{
+			Message: "Wallet at path // was not found",
+		},
+	})
+
+	r, err := c.Call(q)
+	require.NoError(t, err)
+	require.Equal(t, "Wallet at path // was not found", r.Error.Message)
+}
+
+func TestClientCallDoesNotReloadWalletIfAlreadyLoaded(t *testing.T) {
+	var (
+		r *jsonrpc.RPCResponse
+	)
+
+	rand.Seed(time.Now().UnixNano())
+	wid := wallet.MakeID(rand.Intn(100))
+
+	mc := NewMockRPCClient()
+	c := &Client{rpcClient: mc}
+	q, _ := NewQuery(newRawRequest(t, "wallet_balance", nil))
+	q.SetWalletID(wid)
+
+	mc.AddNextResponse(&jsonrpc.RPCResponse{
+		JSONRPC: "2.0",
+		Error: &jsonrpc.RPCError{
+			Message: "Couldn't find wallet: //",
+		},
+	})
+	mc.AddNextResponse(&jsonrpc.RPCResponse{
+		JSONRPC: "2.0",
+		Error: &jsonrpc.RPCError{
+			Message: "Wallet at path // is already loaded",
+		},
+	})
+	mc.AddNextResponse(&jsonrpc.RPCResponse{
+		JSONRPC: "2.0",
+		Result:  `"99999.00"`,
+	})
+
+	r, err := c.Call(q)
+	require.NoError(t, err)
+	require.Nil(t, r.Error)
+	require.Equal(t, `"99999.00"`, r.Result)
 }

--- a/app/proxy/proxy_test.go
+++ b/app/proxy/proxy_test.go
@@ -54,12 +54,12 @@ func parseRawResponse(t *testing.T, rawCallReponse []byte, destinationVar interf
 	rpcResponse.GetObject(destinationVar)
 }
 
-type ClientMock struct {
+type MockClient struct {
 	Delay       time.Duration
 	LastRequest jsonrpc.RPCRequest
 }
 
-func (c *ClientMock) Call(q *Query) (*jsonrpc.RPCResponse, error) {
+func (c *MockClient) Call(q *Query) (*jsonrpc.RPCResponse, error) {
 	c.LastRequest = *q.Request
 	time.Sleep(c.Delay)
 	return &jsonrpc.RPCResponse{
@@ -169,7 +169,7 @@ func TestCallerCallRelaxedMethods(t *testing.T) {
 			if m == MethodStatus {
 				return
 			}
-			mockClient := &ClientMock{}
+			mockClient := &MockClient{}
 			svc := NewService(Opts{SDKRouter: router.NewDefault()})
 			c := Caller{
 				client:  mockClient,
@@ -189,7 +189,7 @@ func TestCallerCallRelaxedMethods(t *testing.T) {
 
 func TestCallerCallNonRelaxedMethods(t *testing.T) {
 	for _, m := range walletSpecificMethods {
-		mockClient := &ClientMock{}
+		mockClient := &MockClient{}
 		svc := NewService(Opts{SDKRouter: router.NewDefault()})
 		c := Caller{
 			client:  mockClient,
@@ -202,7 +202,7 @@ func TestCallerCallNonRelaxedMethods(t *testing.T) {
 }
 
 func TestCallerCallForbiddenMethod(t *testing.T) {
-	mockClient := &ClientMock{}
+	mockClient := &MockClient{}
 	svc := NewService(Opts{SDKRouter: router.NewDefault()})
 	c := Caller{
 		client:  mockClient,
@@ -214,7 +214,7 @@ func TestCallerCallForbiddenMethod(t *testing.T) {
 }
 
 func TestCallerCallAttachesWalletID(t *testing.T) {
-	mockClient := &ClientMock{}
+	mockClient := &MockClient{}
 
 	rand.Seed(time.Now().UnixNano())
 	dummyWalletID := "abc123321"
@@ -240,7 +240,7 @@ func TestCallerCallAttachesWalletID(t *testing.T) {
 
 func TestCallerSetPreprocessor(t *testing.T) {
 	svc := NewService(Opts{SDKRouter: router.NewDefault()})
-	client := &ClientMock{}
+	client := &MockClient{}
 	c := Caller{
 		client:  client,
 		service: svc,

--- a/app/proxy/proxy_test.go
+++ b/app/proxy/proxy_test.go
@@ -98,6 +98,17 @@ func TestNewCaller(t *testing.T) {
 	}
 }
 
+func TestCallerСall(t *testing.T) {
+	c := NewService(Opts{SDKRouter: router.NewDefault()}).NewCaller("abc")
+	for _, rawQ := range []string{``, ` `, `{}`, `[]`, `[{}]`, `[""]`, `""`, `" "`, `{"method": " "}`} {
+		t.Run(rawQ, func(t *testing.T) {
+			r := c.Call([]byte(rawQ))
+			assert.Contains(t, string(r), `"code": -32700`)
+		})
+	}
+
+}
+
 func TestCallerSetWalletID(t *testing.T) {
 	svc := NewService(Opts{SDKRouter: router.NewDefault()})
 	c := svc.NewCaller("abc")

--- a/internal/monitor/sentry.go
+++ b/internal/monitor/sentry.go
@@ -58,8 +58,8 @@ func CaptureException(err error, params ...map[string]string) {
 	})
 }
 
-// captureFailedQuery sends to Sentry details of a failed daemon call.
-func captureFailedQuery(method string, query interface{}, errorResponse interface{}) {
+// CaptureFailedQuery sends to Sentry details of a failed daemon call.
+func CaptureFailedQuery(method string, query interface{}, errorResponse interface{}) {
 	CaptureException(
 		fmt.Errorf("daemon responded with an error when calling method %v", method),
 		map[string]string{

--- a/lbrytv.yml
+++ b/lbrytv.yml
@@ -7,8 +7,6 @@ Debug: 1
 InternalAPIHost: https://api.lbry.com
 ProjectURL: https://lbry.tv
 
-SentryDSN: "https://9ef75ef77a844d4aa35d834d78266477@sentry.io/1416147"
-
 Database:
   Connection: postgres://lbrytv:lbrytv@localhost
   DBName: lbrytv


### PR DESCRIPTION
This is to improve handling and alerting on various race conditions when wallet file is present on the filesystem but not loaded in memory. Depending on the SDK response, we attempt re-loading the wallet and re-issuing the request. 

What was not handled before is a race condition when wallet loading has already been performed by another parallel request to the API (as UI fires them very fast). In this case, SDK fails with an error saying `Wallet at path .+ is already loaded`, now we handle this error and transparently re-issue the request again instead of passing error back to the UI causing its failure.