### PR TITLE
Recovery middleware

### DIFF
--- a/api/benchmarks_test.go
+++ b/api/benchmarks_test.go
@@ -3,7 +3,6 @@ package api
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -18,6 +17,7 @@ import (
 	"github.com/lbryio/lbrytv/app/sdkrouter"
 	"github.com/lbryio/lbrytv/app/wallet"
 	"github.com/lbryio/lbrytv/config"
+	"github.com/lbryio/lbrytv/internal/errors"
 	"github.com/lbryio/lbrytv/internal/responses"
 	"github.com/lbryio/lbrytv/internal/storage"
 	"github.com/lbryio/lbrytv/models"

--- a/api/routes.go
+++ b/api/routes.go
@@ -1,13 +1,11 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
 	"net/http"
-	"runtime/debug"
 	"strings"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/lbryio/lbrytv/app/auth"
 	"github.com/lbryio/lbrytv/app/proxy"
 	"github.com/lbryio/lbrytv/app/publish"
@@ -15,11 +13,7 @@ import (
 	"github.com/lbryio/lbrytv/config"
 	"github.com/lbryio/lbrytv/internal/metrics"
 	"github.com/lbryio/lbrytv/internal/monitor"
-	"github.com/lbryio/lbrytv/internal/responses"
 	"github.com/lbryio/lbrytv/internal/status"
-	"github.com/ybbus/jsonrpc"
-
-	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -29,7 +23,6 @@ var logger = monitor.NewModuleLogger("api")
 func InstallRoutes(r *mux.Router, sdkRouter *sdkrouter.Router) {
 	upHandler := &publish.Handler{UploadPath: config.GetPublishSourceDir()}
 
-	r.Use(recoveryHandler)
 	r.Use(methodTimer)
 
 	r.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
@@ -79,39 +72,5 @@ func methodTimer(next http.Handler) http.Handler {
 			path += "?" + r.URL.RawQuery
 		}
 		metrics.LbrytvCallDurations.WithLabelValues(path).Observe(time.Since(start).Seconds())
-	})
-}
-
-func recoveryHandler(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		recovered, stack := func() (err error, stack []byte) {
-			defer func() {
-				if r := recover(); r != nil {
-					var ok bool
-					err, ok = r.(error)
-					if !ok {
-						err = fmt.Errorf("%v", r)
-					}
-					if !config.IsProduction() {
-						stack = debug.Stack()
-					}
-				}
-			}()
-			next.ServeHTTP(w, r)
-			return err, nil
-		}()
-		if recovered != nil {
-			logger.Log().Errorf("PANIC %v, trace %s", recovered, stack)
-			responses.AddJSONContentType(w)
-			rsp, _ := json.Marshal(jsonrpc.RPCResponse{
-				JSONRPC: "2.0",
-				Error: &jsonrpc.RPCError{
-					Code:    -1,
-					Message: recovered.Error(),
-					Data:    string(stack),
-				},
-			})
-			w.Write(rsp)
-		}
 	})
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gorilla/mux"
 	"github.com/lbryio/lbrytv/app/auth"
 	"github.com/lbryio/lbrytv/app/proxy"
 	"github.com/lbryio/lbrytv/app/publish"
@@ -14,6 +13,8 @@ import (
 	"github.com/lbryio/lbrytv/internal/metrics"
 	"github.com/lbryio/lbrytv/internal/monitor"
 	"github.com/lbryio/lbrytv/internal/status"
+
+	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 

--- a/api/routes_test.go
+++ b/api/routes_test.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bytes"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,7 +12,6 @@ import (
 	"github.com/lbryio/lbrytv/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/ybbus/jsonrpc"
 )
 
 func TestRoutesProxy(t *testing.T) {
@@ -65,54 +63,4 @@ func TestRoutesOptions(t *testing.T) {
 		"X-Lbry-Auth-Token, Origin, X-Requested-With, Content-Type, Accept",
 		rr.Result().Header.Get("Access-Control-Allow-Headers"),
 	)
-}
-
-func TestRecoveryHandler_Panic(t *testing.T) {
-	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		panic("xoxox")
-	})
-	rr := httptest.NewRecorder()
-	r, err := http.NewRequest(http.MethodGet, "/", &bytes.Buffer{})
-	require.NoError(t, err)
-	logger.Disable()
-	assert.NotPanics(t, func() {
-		recoveryHandler(h).ServeHTTP(rr, r)
-	})
-	var res jsonrpc.RPCResponse
-	err = json.Unmarshal(rr.Body.Bytes(), &res)
-	require.NoError(t, err)
-	require.NotNil(t, res.Error)
-	assert.Contains(t, res.Error.Message, "xoxox")
-}
-
-func TestRecoveryHandler_NoPanic(t *testing.T) {
-	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("no panic recovery"))
-	})
-	rr := httptest.NewRecorder()
-	r, err := http.NewRequest(http.MethodGet, "/", &bytes.Buffer{})
-	require.NoError(t, err)
-	assert.NotPanics(t, func() {
-		recoveryHandler(h).ServeHTTP(rr, r)
-	})
-	assert.Equal(t, rr.Body.String(), "no panic recovery")
-
-}
-
-func TestRecoveryHandler_RecoveredPanic(t *testing.T) {
-	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defer func() {
-			if r := recover(); r != nil {
-				w.Write([]byte("panic recovered in here"))
-			}
-		}()
-		panic("xoxoxo")
-	})
-	rr := httptest.NewRecorder()
-	r, err := http.NewRequest(http.MethodGet, "/", &bytes.Buffer{})
-	require.NoError(t, err)
-	assert.NotPanics(t, func() {
-		recoveryHandler(h).ServeHTTP(rr, r)
-	})
-	assert.Equal(t, rr.Body.String(), "panic recovered in here")
 }

--- a/app/auth/auth_test.go
+++ b/app/auth/auth_test.go
@@ -3,7 +3,6 @@ package auth
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -11,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/lbryio/lbrytv/app/wallet"
+	"github.com/lbryio/lbrytv/internal/errors"
 	"github.com/lbryio/lbrytv/models"
 
 	"github.com/stretchr/testify/assert"
@@ -29,7 +29,7 @@ func TestMiddleware(t *testing.T) {
 		if token == "secret-token" {
 			return NewResult(&models.User{ID: 16595}, nil)
 		}
-		return NewResult(nil, errors.New("error"))
+		return NewResult(nil, errors.Base("error"))
 	}
 
 	rr := httptest.NewRecorder()
@@ -52,7 +52,7 @@ func TestMiddlewareAuthFailure(t *testing.T) {
 		if token == "good-token" {
 			return NewResult(&models.User{ID: 1}, nil)
 		}
-		return NewResult(nil, errors.New("incorrect token"))
+		return NewResult(nil, errors.Base("incorrect token"))
 	}
 	Middleware(provider)(http.HandlerFunc(authChecker)).ServeHTTP(rr, r)
 
@@ -72,7 +72,7 @@ func TestMiddlewareNoAuth(t *testing.T) {
 		if token == "good-token" {
 			return NewResult(&models.User{ID: 1}, nil)
 		}
-		return NewResult(nil, errors.New("incorrect token"))
+		return NewResult(nil, errors.Base("incorrect token"))
 	}
 	Middleware(provider)(http.HandlerFunc(authChecker)).ServeHTTP(rr, r)
 
@@ -84,7 +84,7 @@ func TestMiddlewareNoAuth(t *testing.T) {
 }
 
 func TestFromRequestSuccess(t *testing.T) {
-	expected := NewResult(nil, errors.New("a test"))
+	expected := NewResult(nil, errors.Base("a test"))
 	ctx := context.WithValue(context.Background(), ContextKey, expected)
 
 	r, err := http.NewRequestWithContext(ctx, http.MethodPost, "", &bytes.Buffer{})

--- a/app/proxy/processors.go
+++ b/app/proxy/processors.go
@@ -2,10 +2,10 @@ package proxy
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	"github.com/lbryio/lbrytv/config"
+	"github.com/lbryio/lbrytv/internal/errors"
 
 	ljsonrpc "github.com/lbryio/lbry.go/v2/extras/jsonrpc"
 
@@ -79,7 +79,7 @@ func responseProcessorAccountList(response *jsonrpc.RPCResponse, query *jsonrpc.
 		ljsonrpc.Decode(response.Result, accounts)
 		account := getDefaultAccount(accounts)
 		if account == nil {
-			return errors.New("fatal error: no default account found")
+			return errors.Err("fatal error: no default account found")
 		}
 		response.Result = account
 	}

--- a/app/proxy/proxy.go
+++ b/app/proxy/proxy.go
@@ -13,7 +13,6 @@ package proxy
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -21,6 +20,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lbryio/lbrytv/app/sdkrouter"
 	"github.com/lbryio/lbrytv/config"
+	"github.com/lbryio/lbrytv/internal/errors"
 	"github.com/lbryio/lbrytv/internal/lbrynet"
 	"github.com/lbryio/lbrytv/internal/metrics"
 	"github.com/lbryio/lbrytv/internal/monitor"
@@ -151,7 +151,7 @@ func (c *Caller) callQueryWithRetry(q *Query) (*jsonrpc.RPCResponse, error) {
 		// Generally a HTTP transport failure (connect error etc)
 		if err != nil {
 			logger.Log().Errorf("error sending query to %v: %v", c.endpoint, err)
-			return nil, err
+			return nil, errors.Err(err)
 		}
 
 		// This checks if LbrynetServer responded with missing wallet error and tries to reload it,
@@ -218,9 +218,9 @@ func marshalError(err error) []byte {
 }
 
 func isErrWalletNotLoaded(r *jsonrpc.RPCResponse) bool {
-	return r.Error != nil && errors.Is(lbrynet.NewWalletError(0, errors.New(r.Error.Message)), lbrynet.ErrWalletNotLoaded)
+	return r.Error != nil && errors.Is(lbrynet.NewWalletError(0, errors.Err(r.Error.Message)), lbrynet.ErrWalletNotLoaded)
 }
 
 func isErrWalletAlreadyLoaded(r *jsonrpc.RPCResponse) bool {
-	return r.Error != nil && errors.Is(lbrynet.NewWalletError(0, errors.New(r.Error.Message)), lbrynet.ErrWalletAlreadyLoaded)
+	return r.Error != nil && errors.Is(lbrynet.NewWalletError(0, errors.Err(r.Error.Message)), lbrynet.ErrWalletAlreadyLoaded)
 }

--- a/app/proxy/query.go
+++ b/app/proxy/query.go
@@ -2,13 +2,13 @@ package proxy
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/lbryio/lbrytv/internal/errors"
 	"github.com/lbryio/lbrytv/internal/responses"
-	"github.com/sirupsen/logrus"
 
+	"github.com/sirupsen/logrus"
 	"github.com/ybbus/jsonrpc"
 )
 
@@ -22,7 +22,7 @@ type Query struct {
 // The object is immediately usable and returns an error in case request parsing fails.
 func NewQuery(req *jsonrpc.RPCRequest) (*Query, error) {
 	if strings.TrimSpace(req.Method) == "" {
-		return nil, errors.New("no method in request")
+		return nil, errors.Err("no method in request")
 	}
 
 	return &Query{Request: req}, nil
@@ -30,7 +30,7 @@ func NewQuery(req *jsonrpc.RPCRequest) (*Query, error) {
 
 func (q *Query) validate() error {
 	if !methodInList(q.Method(), relaxedMethods) && !methodInList(q.Method(), walletSpecificMethods) {
-		return NewMethodNotAllowedError(errors.New("forbidden method"))
+		return NewMethodNotAllowedError(errors.Err("forbidden method"))
 	}
 
 	if q.ParamsAsMap() != nil {
@@ -41,7 +41,7 @@ func (q *Query) validate() error {
 
 	if MethodNeedsAuth(q.Method()) {
 		if q.WalletID == "" {
-			return NewAuthRequiredError(errors.New(responses.AuthRequiredErrorMessage))
+			return NewAuthRequiredError(errors.Err(responses.AuthRequiredErrorMessage))
 		}
 		if p := q.ParamsAsMap(); p != nil {
 			p[paramWalletID] = q.WalletID

--- a/app/proxy/query_test.go
+++ b/app/proxy/query_test.go
@@ -1,8 +1,9 @@
 package proxy
 
 import (
-	"errors"
 	"testing"
+
+	"github.com/lbryio/lbrytv/internal/errors"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/app/publish/handler_test.go
+++ b/app/publish/handler_test.go
@@ -3,7 +3,6 @@ package publish
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -17,6 +16,7 @@ import (
 	"github.com/lbryio/lbrytv/app/auth"
 	"github.com/lbryio/lbrytv/app/sdkrouter"
 	"github.com/lbryio/lbrytv/app/wallet"
+	"github.com/lbryio/lbrytv/internal/errors"
 	"github.com/lbryio/lbrytv/internal/test"
 	"github.com/lbryio/lbrytv/models"
 
@@ -60,7 +60,7 @@ func TestUploadHandler(t *testing.T) {
 			res.SDKAddress = ts.URL
 			return res
 		}
-		return auth.NewResult(nil, errors.New("error"))
+		return auth.NewResult(nil, errors.Base("error"))
 	}
 
 	rr := httptest.NewRecorder()
@@ -125,7 +125,7 @@ func TestHandler_AuthRequired(t *testing.T) {
 		if token == "uPldrToken" {
 			return auth.NewResult(&models.User{ID: 20404}, nil)
 		}
-		return auth.NewResult(nil, errors.New("error"))
+		return auth.NewResult(nil, errors.Base("error"))
 	}
 
 	rr := httptest.NewRecorder()
@@ -172,7 +172,7 @@ func TestUploadHandlerSystemError(t *testing.T) {
 			res.SDKAddress = "whatever"
 			return res
 		}
-		return auth.NewResult(nil, errors.New("error"))
+		return auth.NewResult(nil, errors.Base("error"))
 	}
 
 	rr := httptest.NewRecorder()

--- a/app/publish/publish.go
+++ b/app/publish/publish.go
@@ -52,13 +52,13 @@ func (h Handler) Handle(w http.ResponseWriter, r *http.Request) {
 	f, err := h.saveFile(r, authResult.User().ID)
 	if err != nil {
 		logger.Log().Error(err)
-		monitor.CaptureException(err)
+		monitor.ErrorToSentry(err)
 		w.Write(proxy.NewInternalError(err).JSON())
 		return
 	}
 	defer func() {
 		if err := os.Remove(f.Name()); err != nil {
-			monitor.CaptureException(err, map[string]string{"file_path": f.Name()})
+			monitor.ErrorToSentry(err, map[string]string{"file_path": f.Name()})
 		}
 	}()
 

--- a/app/publish/publish.go
+++ b/app/publish/publish.go
@@ -1,7 +1,6 @@
 package publish
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/lbryio/lbrytv/app/auth"
 	"github.com/lbryio/lbrytv/app/proxy"
+	"github.com/lbryio/lbrytv/internal/errors"
 	"github.com/lbryio/lbrytv/internal/monitor"
 
 	"github.com/gorilla/mux"
@@ -44,7 +44,7 @@ func (h Handler) Handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if authResult.SDKAddress == "" {
-		w.Write(proxy.NewInternalError(errors.New("user does not have sdk address assigned")).JSON())
+		w.Write(proxy.NewInternalError(errors.Err("user does not have sdk address assigned")).JSON())
 		logger.Log().Errorf("user %d does not have sdk address assigned", authResult.User().ID)
 		return
 	}

--- a/app/wallet/wallet.go
+++ b/app/wallet/wallet.go
@@ -2,20 +2,21 @@ package wallet
 
 import (
 	"database/sql"
-	"errors"
 	"fmt"
 
-	ljsonrpc "github.com/lbryio/lbry.go/v2/extras/jsonrpc"
 	"github.com/lbryio/lbrytv/app/sdkrouter"
+	"github.com/lbryio/lbrytv/internal/errors"
 	"github.com/lbryio/lbrytv/internal/lbrynet"
 	"github.com/lbryio/lbrytv/internal/monitor"
 	"github.com/lbryio/lbrytv/models"
-	"github.com/volatiletech/sqlboiler/queries/qm"
+
+	ljsonrpc "github.com/lbryio/lbry.go/v2/extras/jsonrpc"
 
 	"github.com/lib/pq"
 	pkgerrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/volatiletech/sqlboiler/boil"
+	"github.com/volatiletech/sqlboiler/queries/qm"
 )
 
 var logger = monitor.NewModuleLogger("wallet")
@@ -82,10 +83,10 @@ func getOrCreateLocalUser(remoteUserID int, log *logrus.Entry) (*models.User, er
 // it ensures that the assigned sdk is set on user.R.LbrynetServer, so it can be accessed externally
 func assignSDKServerToUser(user *models.User, server *models.LbrynetServer, log *logrus.Entry) error {
 	if user.ID == 0 {
-		return errors.New("user must already exist in db")
+		return errors.Err("user must already exist in db")
 	}
 	if !user.LbrynetServerID.IsZero() {
-		return errors.New("user already has an sdk assigned")
+		return errors.Err("user already has an sdk assigned")
 	}
 
 	if server.ID == 0 {
@@ -107,18 +108,18 @@ func assignSDKServerToUser(user *models.User, server *models.LbrynetServer, log 
 	)
 	result, err := boil.GetDB().Exec(q, server.ID, user.ID)
 	if err != nil {
-		return err
+		return errors.Err(err)
 	}
 
 	count, err := result.RowsAffected()
 	if err != nil {
-		return err
+		return errors.Err(err)
 	}
 	if count == 0 {
 		// update from another request got there first. reload user to get the assigned server
 		err = user.ReloadG()
 		if err != nil {
-			return err
+			return errors.Err(err)
 		}
 		needsWalletCreation = false // it will have been created by the request that did the successful assignment
 		log.Debugf("user %d: already assigned to a server", user.ID)
@@ -134,7 +135,7 @@ func assignSDKServerToUser(user *models.User, server *models.LbrynetServer, log 
 	}
 	srv, err := user.LbrynetServer().OneG()
 	if err != nil {
-		return err
+		return errors.Err(err)
 	}
 	user.R.LbrynetServer = srv
 	log.Infof("user %d: assigned to sdk %s (%s)", user.ID, server.Name, server.Address)
@@ -143,7 +144,7 @@ func assignSDKServerToUser(user *models.User, server *models.LbrynetServer, log 
 	user.WalletID = sdkrouter.WalletID(user.ID)
 	_, err = user.UpdateG(boil.Infer())
 	if err != nil {
-		return err
+		return errors.Err(err)
 	}
 
 	if needsWalletCreation {

--- a/app/wallet/wallet_test.go
+++ b/app/wallet/wallet_test.go
@@ -1,7 +1,6 @@
 package wallet
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -11,11 +10,13 @@ import (
 
 	"github.com/lbryio/lbrytv/app/sdkrouter"
 	"github.com/lbryio/lbrytv/config"
+	"github.com/lbryio/lbrytv/internal/errors"
 	"github.com/lbryio/lbrytv/internal/lbrynet"
 	"github.com/lbryio/lbrytv/internal/responses"
 	"github.com/lbryio/lbrytv/internal/storage"
 	"github.com/lbryio/lbrytv/internal/test"
 	"github.com/lbryio/lbrytv/models"
+
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/dev.sh
+++ b/dev.sh
@@ -5,12 +5,10 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 (
   cd "$DIR"
 
-  export DEBUGGING=1
+  export LW_DEBUG=1
 
   hash reflex 2>/dev/null || go get github.com/cespare/reflex
   hash reflex 2>/dev/null || { echo >&2 'Make sure '"$(go env GOPATH)"'/bin is in your $PATH'; exit 1;  }
 
-  hash go-bindata 2>/dev/null || go get github.com/jteeuwen/go-bindata/...
-
-  reflex --decoration=none --start-service=true --regex='\.(go|css|js|html)$' --inverse-regex='assets/bindata\.go' --inverse-regex='vendor/' -- sh -c "go generate && go run *.go serve"
+  reflex --decoration=none --start-service=true --regex='\.(go|css|js|html)$' --inverse-regex='assets/bindata\.go' --inverse-regex='vendor/' -- sh -c "go run ."
 )

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 // indirect
-	github.com/pkg/errors v0.8.1
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.1.0
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 // indirect
 	github.com/prometheus/procfs v0.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -400,6 +400,8 @@ github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTw
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,0 +1,162 @@
+package errors
+
+import (
+	base "errors"
+	"fmt"
+	"reflect"
+	"runtime"
+)
+
+// The maximum number of stack frames on any error.
+const maxStackDepth = 50
+
+// interop with pkg/errors
+type causer interface{ Cause() error }
+
+// traced is an error with an attached stack trace
+type traced struct {
+	err    error
+	stack  []uintptr
+	frames []stackFrame
+	prefix string
+}
+
+func (e *traced) Error() string {
+	msg := e.err.Error()
+	if e.prefix != "" {
+		msg = fmt.Sprintf("%s: %s", e.prefix, msg)
+	}
+	return msg
+}
+
+func (e *traced) Unwrap() error {
+	return e.err
+}
+
+func (e *traced) String() string {
+	return e.TypeName() + " " + e.Error()
+}
+
+// Trace returns the call stack formatted the same way that go does in runtime/debug.Stack()
+func (e *traced) Trace() string {
+	trace := ""
+	for _, frame := range e.StackFrames() {
+		trace += frame.String()
+	}
+	return trace
+}
+
+// StackFrames returns an array of frames containing information about the stack.
+// This function must exist with this name for Sentry to report the correct trace.
+// See extractReflectedStacktraceMethod() in github.com/getsentry/sentry-go/stacktrace.go
+func (e *traced) StackFrames() []stackFrame {
+	if e.frames == nil {
+		e.frames = make([]stackFrame, len(e.stack))
+		for i, pc := range e.stack {
+			e.frames[i] = *newStackFrame(pc)
+		}
+	}
+
+	return e.frames
+}
+
+// FullTrace returns a string that contains both the error message and the call stack.
+func (e *traced) FullTrace() string {
+	return e.String() + "\n" + e.Trace()
+}
+
+// TypeName returns the type this error. e.g. *errors.stringError.
+func (e *traced) TypeName() string {
+	return reflect.TypeOf(e.err).String()
+}
+
+//// New replaces builtin errors.New()
+//func New(text string) error {
+//	return Err(text)
+//}
+
+// Err returns an error with stack trace
+func Err(e interface{}, fmtParams ...interface{}) error {
+	return wrap(1, e, fmtParams...)
+}
+
+// wrap intelligently creates/handles errors, while preserving the stack trace.
+// Compatible with errors from github.com/pkg/errors.
+// The skip parameter indicates how far up the stack to start the stacktrace. 0 starts from
+// the function that calls wrap(), 1 from that function's caller, etc.
+func wrap(skip int, e interface{}, fmtParams ...interface{}) *traced {
+	// TODO: should i call this something other than new(), since it doesnt always make a new one?
+	if e == nil {
+		return nil
+	}
+
+	var err error
+
+	switch typed := e.(type) {
+	case *traced:
+		return typed
+	case causer:
+		e = fmt.Errorf("%+v", e) // should this be e.Cause() ??
+	case error:
+		err = typed
+	case string:
+		err = fmt.Errorf(typed, fmtParams...)
+	default:
+		err = fmt.Errorf("%+v", typed)
+	}
+
+	stack := make([]uintptr, maxStackDepth)
+	length := runtime.Callers(2+skip, stack[:])
+	return &traced{
+		err:   err,
+		stack: stack[:length],
+	}
+}
+
+// Is, As, and Unwrap call through to the builtin errors functions with the same name
+func Is(err, target error) bool             { return base.Is(err, target) }
+func As(err error, target interface{}) bool { return base.As(err, target) }
+func Unwrap(err error) error                { return base.Unwrap(err) }
+
+// Prefix prefixes the message of the error with the given string
+func Prefix(prefix string, err interface{}) error {
+	if err == nil {
+		return nil
+	}
+
+	e := wrap(1, err)
+
+	if e.prefix != "" {
+		prefix = fmt.Sprintf("%s: %s", prefix, e.prefix)
+	}
+	e.prefix = prefix
+
+	return e
+}
+
+// Trace returns the stack trace
+func Trace(err error) string {
+	if err == nil {
+		return ""
+	}
+	return wrap(1, err).Trace()
+}
+
+// FullTrace returns the error type, message, and stack trace
+func FullTrace(err error) string {
+	if err == nil {
+		return ""
+	}
+	return wrap(1, err).FullTrace()
+}
+
+// Base returns a simple error with no stack trace attached
+func Base(format string, a ...interface{}) error {
+	return fmt.Errorf(format, a...)
+}
+
+// HasTrace checks if error has a trace attached
+func HasTrace(err error) bool {
+	_, ok := err.(*traced)
+	return ok
+}

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -1,0 +1,22 @@
+package errors
+
+import (
+	base "errors"
+	"testing"
+
+	pkg "github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErr_MultipleLayersOfWrapping(t *testing.T) {
+	orig := base.New("the base error")
+	pkg1 := pkg.Wrap(orig, "wrapped pkg 1")
+	our1 := Err(pkg1)
+	pkg2 := pkg.Wrap(our1, "wrapped pkg 2")
+	our2 := Err(pkg2)
+	assert.True(t, base.Is(our1, orig))
+	assert.True(t, base.Is(our2, orig))
+	assert.True(t, base.Is(pkg2, orig))
+	assert.True(t, base.Is(our2, pkg1))
+	assert.True(t, base.Is(our2, our1))
+}

--- a/internal/errors/stack.go
+++ b/internal/errors/stack.go
@@ -1,0 +1,100 @@
+package errors
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"runtime"
+	"strings"
+)
+
+// stackFrame represents a line in a call stack.
+type stackFrame struct {
+	// The path to the file containing this ProgramCounter
+	File string
+	// The LineNumber in that file
+	LineNumber int
+	// The Name of the function that contains this ProgramCounter
+	Name string
+	// The Package that contains this function
+	Package string
+	// The underlying ProgramCounter
+	ProgramCounter uintptr
+}
+
+// NewStackFrame populates a stack frame object from the program counter.
+func newStackFrame(pc uintptr) (frame *stackFrame) {
+	frame = &stackFrame{ProgramCounter: pc}
+	if frame.Func() == nil {
+		return
+	}
+	frame.Package, frame.Name = packageAndName(frame.Func())
+
+	// pc -1 because the program counters we use are usually return addresses,
+	// and we want to show the line that corresponds to the function call
+	frame.File, frame.LineNumber = frame.Func().FileLine(pc - 1)
+	return
+
+}
+
+// Func returns the function that contained this frame.
+func (frame *stackFrame) Func() *runtime.Func {
+	if frame.ProgramCounter == 0 {
+		return nil
+	}
+	return runtime.FuncForPC(frame.ProgramCounter)
+}
+
+// String returns the stackframe formatted in the same way as go does
+// in runtime/debug.Stack()
+func (frame *stackFrame) String() string {
+	str := fmt.Sprintf("%s:%d (0x%x)\n", frame.File, frame.LineNumber, frame.ProgramCounter)
+
+	source, err := frame.SourceLine()
+	if err == nil {
+		str += fmt.Sprintf("\t%s: %s\n", frame.Name, source)
+	}
+
+	return str
+}
+
+// SourceLine gets the line of code (from File and Line) of the original source if possible.
+func (frame *stackFrame) SourceLine() (string, error) {
+	data, err := ioutil.ReadFile(frame.File)
+
+	if err != nil {
+		return "", Err(err)
+	}
+
+	lines := bytes.Split(data, []byte{'\n'})
+	if frame.LineNumber <= 0 || frame.LineNumber >= len(lines) {
+		return "???", nil
+	}
+	// -1 because line-numbers are 1 based, but our array is 0 based
+	return string(bytes.Trim(lines[frame.LineNumber-1], " \t")), nil
+}
+
+func packageAndName(fn *runtime.Func) (string, string) {
+	name := fn.Name()
+	pkg := ""
+
+	// The name includes the path name to the package, which is unnecessary
+	// since the file name is already included.  Plus, it has center dots.
+	// That is, we see
+	//  runtime/debug.*T·ptrmethod
+	// and want
+	//  *T.ptrmethod
+	// Since the package path might contains dots (e.g. code.google.com/...),
+	// we first remove the path prefix if there is one.
+	if lastslash := strings.LastIndex(name, "/"); lastslash >= 0 {
+		pkg += name[:lastslash] + "/"
+		name = name[lastslash+1:]
+	}
+	if period := strings.Index(name, "."); period >= 0 {
+		pkg += name[:period]
+		name = name[period+1:]
+	}
+
+	name = strings.Replace(name, "·", ".", -1)
+	return pkg, name
+}

--- a/internal/lbrynet/errors.go
+++ b/internal/lbrynet/errors.go
@@ -1,9 +1,10 @@
 package lbrynet
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
+
+	"github.com/lbryio/lbrytv/internal/errors"
 )
 
 type WalletError struct {
@@ -15,11 +16,11 @@ func (e WalletError) Error() string { return fmt.Sprintf("user %d: %s", e.UserID
 func (e WalletError) Unwrap() error { return e.Err }
 
 var (
-	ErrWalletNotFound      = errors.New("wallet not found")
-	ErrWalletExists        = errors.New("wallet exists and is loaded")
-	ErrWalletNeedsLoading  = errors.New("wallet exists and needs to be loaded")
-	ErrWalletNotLoaded     = errors.New("wallet is not loaded")
-	ErrWalletAlreadyLoaded = errors.New("wallet is already loaded")
+	ErrWalletNotFound      = errors.Base("wallet not found")
+	ErrWalletExists        = errors.Base("wallet exists and is loaded")
+	ErrWalletNeedsLoading  = errors.Base("wallet exists and needs to be loaded")
+	ErrWalletNotLoaded     = errors.Base("wallet is not loaded")
+	ErrWalletAlreadyLoaded = errors.Base("wallet is already loaded")
 
 	// Workaround for non-existent SDK error codes
 	reWalletNotFound      = regexp.MustCompile(`Wallet at path .+ was not found`)

--- a/internal/lbrynet/errors.go
+++ b/internal/lbrynet/errors.go
@@ -23,11 +23,11 @@ var (
 	ErrWalletAlreadyLoaded = errors.Base("wallet is already loaded")
 
 	// Workaround for non-existent SDK error codes
-	reWalletNotFound      = regexp.MustCompile(`Wallet at path .+ was not found`)
-	reWalletExists        = regexp.MustCompile(`Wallet at path .+ already exists and is loaded`)
-	reWalletNeedsLoading  = regexp.MustCompile(`Wallet at path .+ already exists, use 'wallet_add' to load wallet`)
-	reWalletNotLoaded     = regexp.MustCompile(`Couldn't find wallet:`)
-	reWalletAlreadyLoaded = regexp.MustCompile(`Wallet at path .+ is already loaded`)
+	reWalletNotFound      = regexp.MustCompile(`(?i)wallet at path .+ was not found`)
+	reWalletExists        = regexp.MustCompile(`(?i)wallet at path .+ already exists and is loaded`)
+	reWalletNeedsLoading  = regexp.MustCompile(`(?i)wallet at path .+ already exists, use 'wallet_add' to load wallet`)
+	reWalletNotLoaded     = regexp.MustCompile(`(?i)couldn't find wallet:`)
+	reWalletAlreadyLoaded = regexp.MustCompile(`(?i)wallet at path .+ is already loaded`)
 )
 
 // NewWalletError converts plain SDK error to the typed one

--- a/internal/lbrynet/errors_test.go
+++ b/internal/lbrynet/errors_test.go
@@ -1,15 +1,16 @@
 package lbrynet
 
 import (
-	"errors"
 	"testing"
+
+	"github.com/lbryio/lbrytv/internal/errors"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestWalletAlreadyLoaded(t *testing.T) {
 	walletErr := &WalletError{}
-	err := NewWalletError(123, errors.New("Wallet at path /tmp/123 is already loaded"))
+	err := NewWalletError(123, errors.Base("wallet at path /tmp/123 is already loaded"))
 	assert.True(t, errors.Is(err, ErrWalletAlreadyLoaded))
 	assert.True(t, errors.As(err, walletErr))
 	assert.Equal(t, 123, walletErr.UserID)

--- a/internal/monitor/middleware.go
+++ b/internal/monitor/middleware.go
@@ -1,10 +1,11 @@
 package monitor
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
+
+	"github.com/lbryio/lbrytv/internal/errors"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/sirupsen/logrus"
@@ -12,7 +13,7 @@ import (
 
 const responseSnippetLength = 500
 
-var errGeneric = errors.New("handler responded with an error")
+var errGeneric = errors.Base("handler responded with an error")
 
 var httpLogger = NewModuleLogger("http_monitor")
 
@@ -66,11 +67,11 @@ func ErrorLoggingMiddleware(next http.Handler) http.Handler {
 			if err := recover(); err != nil {
 				switch t := err.(type) {
 				case string:
-					finalErr = errors.New(t)
+					finalErr = errors.Err(t)
 				case error:
 					finalErr = t
 				default:
-					finalErr = fmt.Errorf("unknown error: %v", err)
+					finalErr = errors.Err("unknown error: %v", err)
 				}
 				http.Error(w, finalErr.Error(), http.StatusInternalServerError)
 			} else if !w.IsSuccess() {

--- a/internal/monitor/middleware.go
+++ b/internal/monitor/middleware.go
@@ -1,104 +1,170 @@
 package monitor
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
+	"runtime/debug"
 
+	"github.com/lbryio/lbrytv/config"
 	"github.com/lbryio/lbrytv/internal/errors"
+	"github.com/lbryio/lbrytv/internal/responses"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/sirupsen/logrus"
+	"github.com/ybbus/jsonrpc"
 )
-
-const responseSnippetLength = 500
 
 var errGeneric = errors.Base("handler responded with an error")
 
 var httpLogger = NewModuleLogger("http_monitor")
 
-// loggingWriter mimics http.ResponseWriter but stores a snippet of response, status code
-// and response size for easier logging
-type loggingWriter struct {
-	http.ResponseWriter
-	Status          int
-	ResponseSnippet string
-	ResponseSize    int
+type responseRecorder struct {
+	StatusCode int
+	Body       *bytes.Buffer
+
+	headerMap   http.Header
+	wroteHeader bool
 }
 
-func (w *loggingWriter) Write(p []byte) (int, error) {
-	if w.ResponseSnippet == "" {
-		var snippet []byte
-		if len(p) > responseSnippetLength {
-			snippet = p[:responseSnippetLength]
-		} else {
-			snippet = p
-		}
-		w.ResponseSnippet = strings.Trim(string(snippet), "\n")
+func (rr *responseRecorder) Header() http.Header {
+	if rr.headerMap == nil {
+		rr.headerMap = make(http.Header)
 	}
-	w.ResponseSize += len(p)
-	return w.ResponseWriter.Write(p)
+	return rr.headerMap
 }
 
-func (w *loggingWriter) WriteHeader(status int) {
-	w.Status = status
-	w.ResponseWriter.WriteHeader(status)
+func (rr *responseRecorder) Write(buf []byte) (int, error) {
+	rr.WriteHeader(200)
+	if rr.Body == nil {
+		rr.Body = new(bytes.Buffer)
+	}
+	rr.Body.Write(buf)
+	return len(buf), nil
 }
 
-func (w *loggingWriter) IsSuccess() bool {
-	return w.Status < http.StatusBadRequest
+func (rr *responseRecorder) WriteHeader(code int) {
+	if rr.wroteHeader {
+		return
+	}
+	rr.StatusCode = code
+	rr.wroteHeader = true
+}
+
+func (rr *responseRecorder) send(w http.ResponseWriter) {
+	// Set headers
+	h := w.Header()
+	for k, vals := range rr.Header() {
+		for _, v := range vals {
+			h.Add(k, v)
+		}
+	}
+
+	// Write status code and other headers
+	if rr.StatusCode > 0 {
+		w.WriteHeader(rr.StatusCode)
+	}
+
+	// Write body (and headers, if they were not written above)
+	if rr.Body != nil {
+		w.Write(rr.Body.Bytes())
+	}
 }
 
 // ErrorLoggingMiddleware intercepts panics and regular error responses from http handlers,
 // handles them in a graceful way, logs and sends them to Sentry
 func ErrorLoggingMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(writer http.ResponseWriter, r *http.Request) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		hub := sentry.CurrentHub().Clone()
 		hub.Scope().SetRequest(sentry.Request{}.FromHTTPRequest(r))
-		ctx := sentry.SetHubOnContext(
-			r.Context(),
-			hub,
-		)
+		ctx := sentry.SetHubOnContext(r.Context(), hub)
 
-		w := &loggingWriter{ResponseWriter: writer}
-
-		defer func() {
-			var finalErr error
-			if err := recover(); err != nil {
-				switch t := err.(type) {
-				case string:
-					finalErr = errors.Err(t)
-				case error:
-					finalErr = t
-				default:
-					finalErr = errors.Err("unknown error: %v", err)
+		// Record response from next handler, recovering any panics therein
+		recorder := &responseRecorder{}
+		recoveredErr, stack := func() (err error, stack []byte) {
+			defer func() {
+				if p := recover(); p != nil {
+					var ok bool
+					err, ok = p.(error)
+					if !ok {
+						err = fmt.Errorf("%v", p)
+					}
+					stack = debug.Stack()
 				}
-				http.Error(w, finalErr.Error(), http.StatusInternalServerError)
-			} else if !w.IsSuccess() {
-				finalErr = errGeneric
-			}
-
-			if finalErr != nil {
-				CaptureRequestError(finalErr, r, w)
-			}
+			}()
+			next.ServeHTTP(recorder, r.WithContext(ctx))
+			return err, stack
 		}()
 
-		next.ServeHTTP(w, r.WithContext(ctx))
+		// No panics. Send recorded response to the real writer
+		if recoveredErr == nil {
+			if recorder.StatusCode >= http.StatusBadRequest {
+				recordRequestError(r, recorder)
+			}
+			recorder.send(w)
+			return
+		}
+
+		// There was a panic. Handle it and send error response
+
+		recordPanic(recoveredErr, r, recorder, stack)
+
+		if config.IsProduction() {
+			stack = nil
+		}
+		responses.AddJSONContentType(w)
+		rsp, _ := json.Marshal(jsonrpc.RPCResponse{
+			JSONRPC: "2.0",
+			Error: &jsonrpc.RPCError{
+				Code:    -1,
+				Message: recoveredErr.Error(),
+				Data:    string(stack),
+			},
+		})
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write(rsp)
 	})
 }
 
-func CaptureRequestError(err error, r *http.Request, w http.ResponseWriter) {
-	fields := logrus.Fields{
-		"method": r.Method,
-		"url":    r.URL.Path,
-	}
-	if lw, ok := w.(*loggingWriter); ok {
-		fields["status"] = fmt.Sprintf("%v", lw.Status)
-		fields["response"] = lw.ResponseSnippet
+func recordRequestError(r *http.Request, rec *responseRecorder) {
+	snippetLen := len(rec.Body.String())
+	if snippetLen > 500 {
+		snippetLen = 500
 	}
 
-	httpLogger.WithFields(fields).Error(err)
-	CaptureException(err)
+	err := errors.Err("handler responded with an error")
+	httpLogger.WithFields(logrus.Fields{
+		"method":   r.Method,
+		"url":      r.URL.Path,
+		"status":   rec.StatusCode,
+		"response": rec.Body.String()[:snippetLen],
+	}).Error(err)
+
+	ErrorToSentry(err, map[string]string{
+		"method":   r.Method,
+		"url":      r.URL.Path,
+		"status":   fmt.Sprintf("%d", rec.StatusCode),
+		"response": rec.Body.String()[:snippetLen],
+	})
+}
+
+func recordPanic(err error, r *http.Request, rec *responseRecorder, stack []byte) {
+	snippetLen := len(rec.Body.String())
+	if snippetLen > 500 {
+		snippetLen = 500
+	}
+
+	httpLogger.WithFields(logrus.Fields{
+		"method":   r.Method,
+		"url":      r.URL.Path,
+		"status":   rec.StatusCode,
+		"response": rec.Body.String()[:snippetLen],
+	}).Error(fmt.Errorf("RECOVERED PANIC: %v, trace: %s", err, string(stack)))
+
+	// TODO: how to send real stack trace to Sentry?
+
+	ErrorToSentry(err)
 	// if hub := sentry.GetHubFromContext(r.Context()); hub != nil {
 	// 	hub.WithScope(func(scope *sentry.Scope) {
 	// 		scope.SetExtras(extra)

--- a/internal/monitor/middleware_test.go
+++ b/internal/monitor/middleware_test.go
@@ -1,7 +1,7 @@
 package monitor
 
 import (
-	"fmt"
+	"encoding/json"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -9,116 +9,138 @@ import (
 	"testing"
 
 	log "github.com/sirupsen/logrus"
-	logrus_test "github.com/sirupsen/logrus/hooks/test"
+	logrusTest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/ybbus/jsonrpc"
 )
 
 type middlewareTestRow struct {
-	NAME             string
-	method           string
-	url              string
-	reqBody          *io.Reader
-	handler          http.HandlerFunc
-	status           int
-	resBody          string
-	lastEntry        *map[string]string
-	lastEntryLevel   log.Level
-	lastEntryMessage string
+	NAME                  string
+	reqBody               *io.Reader
+	handler               http.HandlerFunc
+	expectedStatus        int
+	expectedBody          string
+	expectedJSONMessage   string
+	expectedLogEntry      map[string]interface{}
+	expectedLogLevel      log.Level
+	expectedLogStartsWith string
 }
 
 var testTableErrorLoggingMiddleware = []middlewareTestRow{
 	{
-		NAME:   "Panicking Handler",
-		method: "POST",
-		url:    "/api/",
+		NAME: "Panicking Handler",
 		handler: func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusAccepted)
+			w.Write([]byte(`everything good so far...`))
 			panic("panic ensued")
 		},
-		status:  http.StatusInternalServerError,
-		resBody: "panic ensued\n",
-		lastEntry: &map[string]string{
+		expectedStatus:      http.StatusInternalServerError,
+		expectedJSONMessage: "panic ensued",
+		expectedLogEntry: map[string]interface{}{
 			"method":   "POST",
-			"url":      "/api/",
-			"status":   fmt.Sprintf("%v", http.StatusInternalServerError),
-			"response": "panic ensued",
+			"url":      "/some-endpoint",
+			"status":   http.StatusAccepted, // this is the original status before the panic
+			"response": "everything good so far...",
 		},
-		lastEntryLevel:   log.ErrorLevel,
-		lastEntryMessage: "panic ensued",
+		expectedLogLevel:      log.ErrorLevel,
+		expectedLogStartsWith: "RECOVERED PANIC: panic ensued",
 	},
 
 	{
-		NAME:   "Erroring Handler",
-		method: "POST",
-		url:    "/api/",
+		NAME: "Erroring Handler",
 		handler: func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte(`{"status": "error"}`))
 		},
-		status:  http.StatusBadRequest,
-		resBody: `{"status": "error"}`,
-		lastEntry: &map[string]string{
+		expectedStatus: http.StatusBadRequest,
+		expectedBody:   `{"status": "error"}`,
+		expectedLogEntry: map[string]interface{}{
 			"method":   "POST",
-			"url":      "/api/",
-			"status":   fmt.Sprintf("%v", http.StatusBadRequest),
+			"url":      "/some-endpoint",
+			"status":   http.StatusBadRequest,
 			"response": `{"status": "error"}`,
 		},
-		lastEntryLevel:   log.ErrorLevel,
-		lastEntryMessage: "handler responded with an error",
+		expectedLogLevel:      log.ErrorLevel,
+		expectedLogStartsWith: "handler responded with an error",
 	},
 
 	{
-		NAME:   "Redirecting Handler",
-		method: "POST",
-		url:    "/api/",
+		NAME: "Redirecting Handler",
 		handler: func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, "http://lbry.com", http.StatusPermanentRedirect)
 		},
-		status: http.StatusPermanentRedirect,
+		expectedStatus: http.StatusPermanentRedirect,
 	},
 
 	{
-		NAME:   "Okay Handler",
-		method: "POST",
-		url:    "/api/",
+		NAME: "Okay Handler",
 		handler: func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusAccepted)
 			w.Write([]byte(`OK`))
 		},
-		status:  http.StatusAccepted,
-		resBody: "OK",
+		expectedStatus: http.StatusAccepted,
+		expectedBody:   "OK",
+	},
+
+	{
+		NAME: "Panic Recovered Handler",
+		handler: func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusAccepted)
+			defer func() {
+				if r := recover(); r != nil {
+					w.Write([]byte("recovered in handler"))
+				}
+			}()
+			panic("xoxoxo")
+		},
+		expectedStatus: http.StatusAccepted,
+		expectedBody:   "recovered in handler",
 	},
 }
 
 func TestErrorLoggingMiddlewareTableTest(t *testing.T) {
 	for _, row := range testTableErrorLoggingMiddleware {
 		t.Run(row.NAME, func(t *testing.T) {
-			hook := logrus_test.NewLocal(httpLogger.Entry.Logger)
+			hook := logrusTest.NewLocal(httpLogger.Entry.Logger)
 
 			var reqBody io.Reader
 			if row.reqBody != nil {
 				reqBody = *row.reqBody
 			}
-			r, _ := http.NewRequest(row.method, row.url, reqBody)
+			r, err := http.NewRequest("POST", "/some-endpoint", reqBody)
+			require.NoError(t, err)
 
-			mw := ErrorLoggingMiddleware(row.handler)
 			rr := httptest.NewRecorder()
-			mw.ServeHTTP(rr, r)
+			mw := ErrorLoggingMiddleware(row.handler)
+			assert.NotPanics(t, func() {
+				mw.ServeHTTP(rr, r)
+			})
 			res := rr.Result()
 			body, err := ioutil.ReadAll(res.Body)
 			require.NoError(t, err)
 
-			assert.Equal(t, row.status, res.StatusCode)
-			assert.Equal(t, row.resBody, string(body))
+			assert.Equal(t, row.expectedStatus, res.StatusCode)
+			if row.expectedBody != "" {
+				assert.Equal(t, row.expectedBody, string(body))
+			} else if row.expectedJSONMessage != "" {
+				var decoded jsonrpc.RPCResponse
+				err := json.Unmarshal(body, &decoded)
+				require.NoError(t, err)
+				assert.Equal(t, row.expectedJSONMessage, decoded.Error.Message)
+			} else {
+				assert.Equal(t, "", string(body))
+			}
 
-			if row.lastEntry != nil {
+			if row.expectedLogEntry != nil {
 				if assert.GreaterOrEqual(t, len(hook.Entries), 1, "expected a log entry, got none") {
 					l := hook.LastEntry()
-					assert.Equal(t, row.lastEntryLevel, l.Level)
-					for k, v := range *row.lastEntry {
+					assert.Equal(t, row.expectedLogLevel, l.Level)
+					for k, v := range row.expectedLogEntry {
 						assert.Equal(t, v, l.Data[k], k)
 					}
-					assert.Equal(t, row.lastEntryMessage, l.Message)
+
+					assert.Regexp(t, "^"+row.expectedLogStartsWith, l.Message)
 				}
 			}
 		})

--- a/internal/monitor/sentry.go
+++ b/internal/monitor/sentry.go
@@ -41,8 +41,8 @@ func configureSentry(release, env string) {
 	}
 }
 
-// CaptureException sends to Sentry general exception info with some extra provided detail (like user email, claim url etc)
-func CaptureException(err error, params ...map[string]string) {
+// ErrorToSentry sends to Sentry general exception info with some extra provided detail (like user email, claim url etc)
+func ErrorToSentry(err error, params ...map[string]string) {
 	var extra map[string]string
 	if len(params) > 0 {
 		extra = params[0]

--- a/server/server.go
+++ b/server/server.go
@@ -43,7 +43,8 @@ func NewServer(address string, sdkRouter *sdkrouter.Router) *Server {
 			Addr:    address,
 			Handler: r,
 			// We need this for long uploads
-			WriteTimeout:      0,
+			WriteTimeout: 0,
+			// prev WriteTimeout was (sdkrouter.RPCTimeout + (1 * time.Second)). it must be longer than rpc timeout to allow those timeouts to be handled
 			IdleTimeout:       0,
 			ReadHeaderTimeout: 10 * time.Second,
 		},


### PR DESCRIPTION
- copied in and improved our errors package. the one in lbrytv should replace the one in lbry.go
- new errors package has a method that's necessary for Sentry to show the correct stack trace for our errors
- merged and improved error handling middleware


future work:
- merge all our various go libraries into lbry.go so we don't have them littered around our repos