### PR TITLE
Postgres tx fix

### DIFF
--- a/api/benchmarks_test.go
+++ b/api/benchmarks_test.go
@@ -72,10 +72,10 @@ func TestMain(m *testing.M) {
 	}
 	dbConn, connCleanup := storage.CreateTestConn(params)
 	dbConn.SetDefaultConnection()
-	defer connCleanup()
 
 	code := m.Run()
 
+	connCleanup()
 	os.Exit(code)
 }
 

--- a/app/proxy/accounts_test.go
+++ b/app/proxy/accounts_test.go
@@ -35,12 +35,13 @@ func TestMain(m *testing.M) {
 		DBName:     dbConfig.DBName,
 		Options:    dbConfig.Options,
 	}
-	c, connCleanup := storage.CreateTestConn(params)
-	c.SetDefaultConnection()
+	dbConn, connCleanup := storage.CreateTestConn(params)
+	dbConn.SetDefaultConnection()
 
-	defer connCleanup()
+	code := m.Run()
 
-	os.Exit(m.Run())
+	connCleanup()
+	os.Exit(code)
 }
 
 func testFuncSetup() {

--- a/app/publish/publish_test.go
+++ b/app/publish/publish_test.go
@@ -26,14 +26,13 @@ func copyToDocker(t *testing.T, fileName string) {
 
 func TestLbrynetPublisher(t *testing.T) {
 	dbConfig := config.GetDatabase()
-	params := storage.ConnParams{
+	c, connCleanup := storage.CreateTestConn(storage.ConnParams{
 		Connection: dbConfig.Connection,
 		DBName:     dbConfig.DBName,
 		Options:    dbConfig.Options,
-	}
-	c, connCleanup := storage.CreateTestConn(params)
-	c.SetDefaultConnection()
+	})
 	defer connCleanup()
+	c.SetDefaultConnection()
 
 	data := []byte("test file")
 	f, err := ioutil.TempFile(os.TempDir(), "*")

--- a/app/sdkrouter/sdkrouter_test.go
+++ b/app/sdkrouter/sdkrouter_test.go
@@ -20,8 +20,11 @@ func TestMain(m *testing.M) {
 	}
 	dbConn, connCleanup := storage.CreateTestConn(params)
 	dbConn.SetDefaultConnection()
-	defer connCleanup()
-	os.Exit(m.Run())
+
+	code := m.Run()
+
+	connCleanup()
+	os.Exit(code)
 }
 
 func TestInitializeWithYML(t *testing.T) {

--- a/app/wallet/tracker/tracker_test.go
+++ b/app/wallet/tracker/tracker_test.go
@@ -37,12 +37,13 @@ func TestMain(m *testing.M) {
 		DBName:     dbConfig.DBName,
 		Options:    dbConfig.Options + "&TimeZone=UTC",
 	}
-	c, connCleanup := storage.CreateTestConn(params)
-	c.SetDefaultConnection()
+	dbConn, connCleanup := storage.CreateTestConn(params)
+	dbConn.SetDefaultConnection()
 
-	defer connCleanup()
+	code := m.Run()
 
-	os.Exit(m.Run())
+	connCleanup()
+	os.Exit(code)
 }
 
 func TestTouch(t *testing.T) {

--- a/app/wallet/wallet.go
+++ b/app/wallet/wallet.go
@@ -27,8 +27,13 @@ var logger = monitor.NewModuleLogger("wallet")
 func DisableLogger() { logger.Disable() } // for testing
 
 // TokenHeader is the name of HTTP header which is supplied by client and should contain internal-api auth_token.
-const TokenHeader = "X-Lbry-Auth-Token"
-const pgUniqueConstraintViolation = "23505"
+const (
+	TokenHeader = "X-Lbry-Auth-Token"
+
+	pgUniqueConstraintViolation   = "23505"
+	pgAbortedTransactionViolation = "25P02"
+	txMaxRetries                  = 2
+)
 
 // GetUserWithWallet gets user by internal-apis auth token. If the user does not have a
 // wallet yet, they are assigned an SDK and a wallet is created for them on that SDK.
@@ -53,7 +58,7 @@ func GetUserWithSDKServer(rt *sdkrouter.Router, internalAPIHost, token, metaRemo
 	defer cancelFn()
 
 	var localUser *models.User
-	err = tx(ctx, storage.Conn.DB.DB, func(tx *sql.Tx) error {
+	err = inTx(ctx, storage.Conn.DB.DB, func(tx *sql.Tx) error {
 		localUser, err = getOrCreateLocalUser(tx, remoteUser.ID, log)
 		if err != nil {
 			return err
@@ -71,65 +76,86 @@ func GetUserWithSDKServer(rt *sdkrouter.Router, internalAPIHost, token, metaRemo
 	return localUser, err
 }
 
-func tx(ctx context.Context, db *sql.DB, fn func(tx *sql.Tx) error) error {
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return err
+func inTx(ctx context.Context, db *sql.DB, f func(tx *sql.Tx) error) error {
+	var (
+		tx  *sql.Tx
+		err error
+	)
+
+	for i := 0; i < txMaxRetries; i++ {
+		tx, err = db.BeginTx(ctx, nil)
+		if err != nil {
+			return err
+		}
+
+		err = f(tx)
+
+		if err == nil {
+			return tx.Commit()
+		}
+
+		rollbackErr := tx.Rollback()
+		if rollbackErr != nil {
+			logger.Log().Errorf("rolling back tx: %v", rollbackErr)
+		}
+
+		// in postgres, if an error occurs inside a transaction, you can't do anything else
+		// you havee to roll the transaction back and start a new one
+		// more info: https://community.pivotal.io/s/article/How-to-Overcome-the-Error-current-transaction-is-aborted-commands-ignored-until-end-of-transaction-block
+		var pgErr *pq.Error
+		if errors.As(err, &pgErr) && pgErr.Code == pgAbortedTransactionViolation {
+			logger.Log().Debug("attempted query in aborted transaction, re-trying")
+			continue
+		}
+
+		break
 	}
 
-	err = fn(tx)
-	if err != nil {
-		tx.Rollback()
-		return err
-	}
-
-	return tx.Commit()
+	return err
 }
 
 func getOrCreateLocalUser(exec boil.Executor, remoteUserID int, log *logrus.Entry) (*models.User, error) {
 	localUser, err := getDBUser(exec, remoteUserID)
-	if err != nil && err != sql.ErrNoRows {
-		return nil, err
-	} else if err == sql.ErrNoRows {
-		log.Infof("user not found in the database, creating")
-		localUser, err = createDBUser(exec, remoteUserID)
-		if err != nil {
-			return nil, err
+
+	if err == nil {
+		if localUser.LbrynetServerID.IsZero() {
+			// Should not happen, but not enforced in DB structure yet
+			log.Errorf("user %d found in db but doesn't have sdk assigned", localUser.ID)
 		}
-	} else if localUser.LbrynetServerID.IsZero() {
-		// Should not happen, but not enforced in DB structure yet
-		log.Errorf("user %d found in db but doesn't have sdk assigned", localUser.ID)
+		return localUser, nil
 	}
 
-	return localUser, nil
-}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return nil, err
+	}
 
-func createDBUser(exec boil.Executor, id int) (*models.User, error) {
-	log := logger.WithFields(logrus.Fields{"id": id})
+	log.Infof("user not found in the database, creating")
 
-	u := &models.User{ID: id}
-	err := u.Insert(exec, boil.Infer())
+	u := &models.User{ID: remoteUserID}
+	err = u.Insert(exec, boil.Infer())
 	if err == nil {
 		metrics.LbrytvNewUsers.Inc()
 		return u, nil
 	}
 
-	// Check if we encountered a primary key violation, it would mean another routine
-	// fired from another request has managed to create a user before us so we should try retrieving it again.
+	// Check if we encountered a primary key violation, it would mean another routine fired another
+	// request managed to create a user before us and we should retrieve that user record.
 	var pgErr *pq.Error
 	if errors.As(err, &pgErr) && pgErr.Code == pgUniqueConstraintViolation {
 		log.Info("user creation conflict, trying to retrieve the local user again")
-		return getDBUser(exec, id)
+		return getDBUser(exec, remoteUserID)
 	}
+
 	log.Error("unknown error encountered while creating user:", err)
 	return nil, err
 }
 
 func getDBUser(exec boil.Executor, id int) (*models.User, error) {
-	return models.Users(
+	user, err := models.Users(
 		models.UserWhere.ID.EQ(id),
 		qm.Load(models.UserRels.LbrynetServer),
 	).One(exec)
+	return user, errors.Err(err)
 }
 
 // assignSDKServerToUser permanently assigns an sdk to a user, and creates a wallet on that sdk for that user.

--- a/app/wallet/wallet_test.go
+++ b/app/wallet/wallet_test.go
@@ -36,9 +36,10 @@ func TestMain(m *testing.M) {
 	}
 	dbConn, connCleanup := storage.CreateTestConn(params)
 	dbConn.SetDefaultConnection()
-	defer connCleanup()
 
 	code := m.Run()
+
+	connCleanup()
 	os.Exit(code)
 }
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -71,7 +71,11 @@ func (e *traced) TypeName() string {
 
 // Err returns an error with stack trace
 func Err(e interface{}, fmtParams ...interface{}) error {
-	return wrap(1, e, fmtParams...)
+	err := wrap(1, e, fmtParams...)
+	if err == nil {
+		return nil // need this so we don't return a nil *traced pointer, only a real nil
+	}
+	return err
 }
 
 // wrap intelligently creates/handles errors, while preserving the stack trace.

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -53,3 +53,10 @@ func itPanics() {
 func itPanicsDeeper() {
 	panic("But who shall dwell in these worlds if they be inhabited?… Are we or they Lords of the World?… And how are all things made for man?")
 }
+
+func TestErr_NilPointer(t *testing.T) {
+	e := Err(nil)
+	assert.NotPanics(t, func() {
+		Unwrap(e)
+	})
+}


### PR DESCRIPTION
Things to note:

1. `os.Exit()` doens't run deferred functions so we weren't cleaning up our test databases. This fixes that, but keep in mind that if you run tests inside Goland and you stop the test partway, it'll still leave the db around.

2. if a query errors inside a postgres transaction, the transaction is aborted and you have to roll it back and start over from scratch. i added code to do that once automatically. the concrete use case for us is if you try to insert a user in a tx and the user exists, you can't fetch that user inside the same tx