### PR TITLE
E2e metrics

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -61,6 +61,7 @@ func defaultMiddlewares(rt *sdkrouter.Router, internalAPIHost string) mux.Middle
 	authProvider := auth.NewIAPIProvider(rt, internalAPIHost)
 	memCache := cache.NewMemoryCache()
 	return middleware.Chain(
+		metrics.Measure(),
 		ip.Middleware,
 		sdkrouter.Middleware(rt),
 		auth.Middleware(authProvider),

--- a/api/routes.go
+++ b/api/routes.go
@@ -61,7 +61,7 @@ func defaultMiddlewares(rt *sdkrouter.Router, internalAPIHost string) mux.Middle
 	authProvider := auth.NewIAPIProvider(rt, internalAPIHost)
 	memCache := cache.NewMemoryCache()
 	return middleware.Chain(
-		metrics.Measure(),
+		metrics.MeasureMiddleware(),
 		ip.Middleware,
 		sdkrouter.Middleware(rt),
 		auth.Middleware(authProvider),

--- a/app/auth/auth.go
+++ b/app/auth/auth.go
@@ -1,17 +1,13 @@
 package auth
 
 import (
-	"context"
 	"net/http"
 
-	"github.com/gorilla/mux"
 	"github.com/lbryio/lbrytv/app/sdkrouter"
 	"github.com/lbryio/lbrytv/app/wallet"
 	"github.com/lbryio/lbrytv/internal/errors"
-	"github.com/lbryio/lbrytv/internal/ip"
 	"github.com/lbryio/lbrytv/internal/monitor"
 	"github.com/lbryio/lbrytv/models"
-	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -21,9 +17,9 @@ var (
 	ErrNoAuthInfo = errors.Base("authentication token missing")
 )
 
-const contextKey ctxKey = iota
-
 type ctxKey int
+
+const contextKey ctxKey = iota
 
 type result struct {
 	user *models.User
@@ -50,33 +46,4 @@ func NewIAPIProvider(rt *sdkrouter.Router, internalAPIHost string) Provider {
 	return func(token, metaRemoteIP string) (*models.User, error) {
 		return wallet.GetUserWithSDKServer(rt, internalAPIHost, token, metaRemoteIP)
 	}
-}
-
-// Middleware tries to authenticate user using request header
-func Middleware(provider Provider) mux.MiddlewareFunc {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			var user *models.User
-			var err error
-			if token, ok := r.Header[wallet.TokenHeader]; ok {
-				addr := ip.FromRequest(r)
-				user, err = provider(token[0], addr)
-				if err != nil {
-					logger.WithFields(logrus.Fields{"ip": addr}).Debugf("error authenticating user")
-				}
-			} else {
-				err = errors.Err(ErrNoAuthInfo)
-			}
-			next.ServeHTTP(w, r.Clone(context.WithValue(r.Context(), contextKey, result{user, err})))
-		})
-	}
-}
-
-// NilMiddleware is useful when you need to test your logic without involving real authentication
-var NilMiddleware = Middleware(nilProvider)
-
-// MiddlewareWithProvider is useful when you want to
-func MiddlewareWithProvider(rt *sdkrouter.Router, internalAPIHost string) mux.MiddlewareFunc {
-	p := NewIAPIProvider(rt, internalAPIHost)
-	return Middleware(p)
 }

--- a/app/auth/middleware.go
+++ b/app/auth/middleware.go
@@ -1,0 +1,43 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/lbryio/lbrytv/app/sdkrouter"
+	"github.com/lbryio/lbrytv/app/wallet"
+	"github.com/lbryio/lbrytv/internal/errors"
+	"github.com/lbryio/lbrytv/internal/ip"
+	"github.com/lbryio/lbrytv/models"
+	"github.com/sirupsen/logrus"
+)
+
+// Middleware tries to authenticate user using request header
+func Middleware(provider Provider) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var user *models.User
+			var err error
+			if token, ok := r.Header[wallet.TokenHeader]; ok {
+				addr := ip.FromRequest(r)
+				user, err = provider(token[0], addr)
+				if err != nil {
+					logger.WithFields(logrus.Fields{"ip": addr}).Debugf("error authenticating user")
+				}
+			} else {
+				err = errors.Err(ErrNoAuthInfo)
+			}
+			next.ServeHTTP(w, r.Clone(context.WithValue(r.Context(), contextKey, result{user, err})))
+		})
+	}
+}
+
+// NilMiddleware is useful when you need to test your logic without involving real authentication
+var NilMiddleware = Middleware(nilProvider)
+
+// MiddlewareWithProvider is useful when you want to
+func MiddlewareWithProvider(rt *sdkrouter.Router, internalAPIHost string) mux.MiddlewareFunc {
+	p := NewIAPIProvider(rt, internalAPIHost)
+	return Middleware(p)
+}

--- a/app/proxy/proxy.go
+++ b/app/proxy/proxy.go
@@ -33,36 +33,26 @@ import (
 
 var logger = monitor.NewModuleLogger("proxy")
 
-type observer struct {
-	*metrics.Timer
+// observeFailure requires metrics.Measure middleware to be present on the request
+func observeFailure(d float64, method, endpoint, kind string) {
+	metrics.ProxyE2ECallDurations.WithLabelValues(method, endpoint).Observe(d)
+	metrics.ProxyE2ECallFailedDurations.WithLabelValues(method, endpoint, kind).Observe(d)
 }
 
-func newObserver() *observer {
-	return &observer{metrics.StartTimer()}
-}
-
-func (o *observer) observeFailure(method, endpoint, kind string) {
-	o.Stop()
-	metrics.ProxyE2ECallDurations.WithLabelValues(method, endpoint).Observe(o.Duration)
-	metrics.ProxyE2ECallFailedDurations.WithLabelValues(method, endpoint, kind).Observe(o.Duration)
-}
-
-func (o *observer) observeSuccess(method, endpoint string) {
-	o.Stop()
-	metrics.ProxyE2ECallDurations.WithLabelValues(method, endpoint).Observe(o.Duration)
+// observeSuccess requires metrics.Measure middleware to be present on the request
+func observeSuccess(d float64, method, endpoint string) {
+	metrics.ProxyE2ECallDurations.WithLabelValues(method, endpoint).Observe(d)
 }
 
 // Handle forwards client JSON-RPC request to proxy.
 func Handle(w http.ResponseWriter, r *http.Request) {
 	responses.AddJSONContentType(w)
 
-	o := newObserver()
-
 	if r.Body == nil {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write(rpcerrors.NewJSONParseError(errors.Err("empty request body")).JSON())
 
-		o.observeFailure("", "", metrics.FailureKindClient)
+		observeFailure(metrics.GetDuration(r), "", "", metrics.FailureKindClient)
 		logger.Log().Debugf("empty request body")
 		return
 	}
@@ -72,7 +62,7 @@ func Handle(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write(rpcerrors.NewJSONParseError(errors.Err("error reading request body")).JSON())
 
-		o.observeFailure("", "", metrics.FailureKindClient)
+		observeFailure(metrics.GetDuration(r), "", "", metrics.FailureKindClient)
 		logger.Log().Debugf("error reading request body: %v", err.Error())
 
 		return
@@ -83,7 +73,7 @@ func Handle(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		w.Write(rpcerrors.NewJSONParseError(err).JSON())
 
-		o.observeFailure("", "", metrics.FailureKindClientJSON)
+		observeFailure(metrics.GetDuration(r), "", "", metrics.FailureKindClientJSON)
 		logger.Log().Debugf("error unmarshaling request body: %v", err)
 
 		return
@@ -96,7 +86,7 @@ func Handle(w http.ResponseWriter, r *http.Request) {
 		authErr := GetAuthError(user, err)
 		if authErr != nil {
 			w.Write(rpcerrors.ErrorToJSON(authErr))
-			o.observeFailure(rpcReq.Method, "", metrics.FailureKindAuth)
+			observeFailure(metrics.GetDuration(r), rpcReq.Method, "", metrics.FailureKindAuth)
 
 			return
 		}
@@ -140,7 +130,7 @@ func Handle(w http.ResponseWriter, r *http.Request) {
 		w.Write(rpcerrors.ToJSON(err))
 
 		logger.Log().Errorf("error calling lbrynet: %v, request: %+v", err, rpcReq)
-		o.observeFailure(rpcReq.Method, sdkAddress, metrics.FailureKindNet)
+		observeFailure(metrics.GetDuration(r), rpcReq.Method, sdkAddress, metrics.FailureKindNet)
 
 		return
 	}
@@ -151,20 +141,20 @@ func Handle(w http.ResponseWriter, r *http.Request) {
 		w.Write(rpcerrors.NewInternalError(err).JSON())
 
 		logger.Log().Errorf("error marshaling response: %v", err)
-		o.observeFailure(rpcReq.Method, sdkAddress, metrics.FailureKindRPCJSON)
+		observeFailure(metrics.GetDuration(r), rpcReq.Method, sdkAddress, metrics.FailureKindRPCJSON)
 
 		return
 	}
 
 	if rpcRes.Error != nil {
-		o.observeFailure(rpcReq.Method, sdkAddress, metrics.FailureKindRPC)
+		observeFailure(metrics.GetDuration(r), rpcReq.Method, sdkAddress, metrics.FailureKindRPC)
 		logger.WithFields(logrus.Fields{
 			"method":   rpcReq.Method,
 			"endpoint": sdkAddress,
 			"response": rpcRes.Error,
 		}).Errorf("proxy handler got rpc error: %v", rpcRes.Error)
 	} else {
-		o.observeSuccess(rpcReq.Method, sdkAddress)
+		observeSuccess(metrics.GetDuration(r), rpcReq.Method, sdkAddress)
 	}
 
 	w.Write(serialized)

--- a/app/proxy/proxy.go
+++ b/app/proxy/proxy.go
@@ -33,13 +33,13 @@ import (
 
 var logger = monitor.NewModuleLogger("proxy")
 
-// observeFailure requires metrics.Measure middleware to be present on the request
+// observeFailure requires metrics.MeasureMiddleware middleware to be present on the request
 func observeFailure(d float64, method, endpoint, kind string) {
 	metrics.ProxyE2ECallDurations.WithLabelValues(method, endpoint).Observe(d)
 	metrics.ProxyE2ECallFailedDurations.WithLabelValues(method, endpoint, kind).Observe(d)
 }
 
-// observeSuccess requires metrics.Measure middleware to be present on the request
+// observeSuccess requires metrics.MeasureMiddleware middleware to be present on the request
 func observeSuccess(d float64, method, endpoint string) {
 	metrics.ProxyE2ECallDurations.WithLabelValues(method, endpoint).Observe(d)
 }

--- a/app/proxy/proxy.go
+++ b/app/proxy/proxy.go
@@ -37,11 +37,14 @@ var logger = monitor.NewModuleLogger("proxy")
 func observeFailure(d float64, method, endpoint, kind string) {
 	metrics.ProxyE2ECallDurations.WithLabelValues(method, endpoint).Observe(d)
 	metrics.ProxyE2ECallFailedDurations.WithLabelValues(method, endpoint, kind).Observe(d)
+	metrics.ProxyE2ECallCounter.WithLabelValues(method, endpoint).Inc()
+	metrics.ProxyE2ECallFailedCounter.WithLabelValues(method, endpoint, kind).Inc()
 }
 
 // observeSuccess requires metrics.MeasureMiddleware middleware to be present on the request
 func observeSuccess(d float64, method, endpoint string) {
 	metrics.ProxyE2ECallDurations.WithLabelValues(method, endpoint).Observe(d)
+	metrics.ProxyE2ECallCounter.WithLabelValues(method, endpoint).Inc()
 }
 
 // Handle forwards client JSON-RPC request to proxy.

--- a/app/proxy/proxy.go
+++ b/app/proxy/proxy.go
@@ -38,17 +38,17 @@ type observer struct {
 }
 
 func newObserver() *observer {
-	return &observer{metrics.TimerStart()}
+	return &observer{metrics.StartTimer()}
 }
 
 func (o *observer) observeFailure(method, endpoint, kind string) {
-	o.Done()
+	o.Stop()
 	metrics.ProxyE2ECallDurations.WithLabelValues(method, endpoint).Observe(o.Duration)
 	metrics.ProxyE2ECallFailedDurations.WithLabelValues(method, endpoint, kind).Observe(o.Duration)
 }
 
 func (o *observer) observeSuccess(method, endpoint string) {
-	o.Done()
+	o.Stop()
 	metrics.ProxyE2ECallDurations.WithLabelValues(method, endpoint).Observe(o.Duration)
 }
 

--- a/internal/lbrynext/lbrynext.go
+++ b/internal/lbrynext/lbrynext.go
@@ -56,6 +56,8 @@ func experimentNewSdkParam(c *query.Caller, hctx *query.HookContext) (*jsonrpc.R
 
 			metrics.LbrynetXCallDurations.WithLabelValues(q.Method(), c.Endpoint(), metrics.GroupControl).Observe(c.Duration)
 			metrics.LbrynetXCallDurations.WithLabelValues(q.Method(), cc.Endpoint(), metrics.GroupExperimental).Observe(cc.Duration)
+			metrics.LbrynetXCallCounter.WithLabelValues(q.Method(), c.Endpoint(), metrics.GroupControl).Inc()
+			metrics.LbrynetXCallCounter.WithLabelValues(q.Method(), cc.Endpoint(), metrics.GroupExperimental).Inc()
 
 			log := logger.Log().WithField("method", query.MethodResolve)
 			if err != nil {
@@ -67,6 +69,9 @@ func experimentNewSdkParam(c *query.Caller, hctx *query.HookContext) (*jsonrpc.R
 				metrics.LbrynetXCallFailedDurations.WithLabelValues(
 					q.Method(), cc.Endpoint(), metrics.GroupExperimental, metrics.FailureKindLbrynetXMismatch,
 				).Observe(cc.Duration)
+				metrics.LbrynetXCallFailedCounter.WithLabelValues(
+					q.Method(), cc.Endpoint(), metrics.GroupExperimental, metrics.FailureKindLbrynetXMismatch,
+				).Inc()
 
 				var requestStr string
 				request, err := json.Marshal(q.Request)
@@ -106,6 +111,8 @@ func experimentParallel(c *query.Caller, hctx *query.HookContext) (*jsonrpc.RPCR
 
 		metrics.LbrynetXCallDurations.WithLabelValues(q.Method(), c.Endpoint(), metrics.GroupControl).Observe(c.Duration)
 		metrics.LbrynetXCallDurations.WithLabelValues(q.Method(), cc.Endpoint(), metrics.GroupExperimental).Observe(cc.Duration)
+		metrics.LbrynetXCallCounter.WithLabelValues(q.Method(), c.Endpoint(), metrics.GroupControl).Inc()
+		metrics.LbrynetXCallCounter.WithLabelValues(q.Method(), cc.Endpoint(), metrics.GroupExperimental).Inc()
 
 		log := logger.Log().WithField("method", query.MethodResolve)
 		if err != nil {
@@ -117,6 +124,9 @@ func experimentParallel(c *query.Caller, hctx *query.HookContext) (*jsonrpc.RPCR
 			metrics.LbrynetXCallFailedDurations.WithLabelValues(
 				q.Method(), cc.Endpoint(), metrics.GroupExperimental, metrics.FailureKindLbrynetXMismatch,
 			).Observe(cc.Duration)
+			metrics.LbrynetXCallFailedCounter.WithLabelValues(
+				q.Method(), cc.Endpoint(), metrics.GroupExperimental, metrics.FailureKindLbrynetXMismatch,
+			).Inc()
 
 			msg := fmt.Sprintf("experimental `%v` call result differs", q.Method())
 			if config.IsProduction() {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -55,7 +55,7 @@ var (
 		prometheus.HistogramOpts{
 			Namespace: nsProxy,
 			Subsystem: "e2e_calls",
-			Name:      "total",
+			Name:      "total_seconds",
 			Help:      "End-to-end method call latency distributions",
 			Buckets:   callsSecondsBuckets,
 		},
@@ -65,9 +65,27 @@ var (
 		prometheus.HistogramOpts{
 			Namespace: nsProxy,
 			Subsystem: "e2e_calls",
-			Name:      "failed",
+			Name:      "failed_seconds",
 			Help:      "Failed end-to-end method call latency distributions",
 			Buckets:   callsSecondsBuckets,
+		},
+		[]string{"method", "endpoint", "kind"},
+	)
+	ProxyE2ECallCounter = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: nsProxy,
+			Subsystem: "e2e_calls",
+			Name:      "total_count",
+			Help:      "End-to-end method call count",
+		},
+		[]string{"method", "endpoint"},
+	)
+	ProxyE2ECallFailedCounter = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: nsProxy,
+			Subsystem: "e2e_calls",
+			Name:      "failed_count",
+			Help:      "Failed end-to-end method call count",
 		},
 		[]string{"method", "endpoint", "kind"},
 	)
@@ -89,6 +107,24 @@ var (
 			Name:      "failed_seconds",
 			Help:      "Failed method call latency distributions",
 			Buckets:   callsSecondsBuckets,
+		},
+		[]string{"method", "endpoint", "kind"},
+	)
+	ProxyCallCounter = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: nsProxy,
+			Subsystem: "calls",
+			Name:      "total_count",
+			Help:      "Method call count",
+		},
+		[]string{"method", "endpoint"},
+	)
+	ProxyCallFailedCounter = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: nsProxy,
+			Subsystem: "calls",
+			Name:      "failed_count",
+			Help:      "Failed method call count",
 		},
 		[]string{"method", "endpoint", "kind"},
 	)
@@ -206,6 +242,24 @@ var (
 			Name:      "failed_seconds",
 			Help:      "Failed method call latency distributions",
 			Buckets:   callsSecondsBuckets,
+		},
+		[]string{"method", "endpoint", "group", "kind"},
+	)
+	LbrynetXCallCounter = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: nsLbrynext,
+			Subsystem: "calls",
+			Name:      "total_count",
+			Help:      "Method call count",
+		},
+		[]string{"method", "endpoint", "group"},
+	)
+	LbrynetXCallFailedCounter = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: nsLbrynext,
+			Subsystem: "calls",
+			Name:      "failed_count",
+			Help:      "Failed method call count",
 		},
 		[]string{"method", "endpoint", "group", "kind"},
 	)

--- a/internal/metrics/middleware.go
+++ b/internal/metrics/middleware.go
@@ -13,7 +13,9 @@ type key int
 
 const timerContextKey key = iota
 
-// Chain chains multiple middleware together
+// Measure middleware starts a timer whenever a request is performed.
+// Note that it doesn't catch any metrics by itself,
+// HTTP handlers are expected to add their own by calling AddObserver.
 func Measure() mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -27,6 +29,7 @@ func Measure() mux.MiddlewareFunc {
 	}
 }
 
+// AddObserver adds Prometheus metric to a chain of observers for a given HTTP request.
 func AddObserver(r *http.Request, o prometheus.Observer) error {
 	v := r.Context().Value(timerContextKey)
 	if v == nil {

--- a/internal/metrics/middleware.go
+++ b/internal/metrics/middleware.go
@@ -14,6 +14,7 @@ type key int
 const timerContextKey key = iota
 
 // Measure middleware starts a timer whenever a request is performed.
+// It should be added as first in the chain of middlewares.
 // Note that it doesn't catch any metrics by itself,
 // HTTP handlers are expected to add their own by calling AddObserver.
 func Measure() mux.MiddlewareFunc {
@@ -38,4 +39,15 @@ func AddObserver(r *http.Request, o prometheus.Observer) error {
 	t := v.(*Timer)
 	t.AddObserver(o)
 	return nil
+}
+
+// GetDuration returns current duration of the request in seconds.
+// Returns a negative value when Measure middleware is not present.
+func GetDuration(r *http.Request) float64 {
+	v := r.Context().Value(timerContextKey)
+	if v == nil {
+		return -1
+	}
+	t := v.(*Timer)
+	return t.GetDuration()
 }

--- a/internal/metrics/middleware.go
+++ b/internal/metrics/middleware.go
@@ -13,19 +13,22 @@ type key int
 
 const timerContextKey key = iota
 
-// Measure middleware starts a timer whenever a request is performed.
+// MeasureMiddleware starts a timer whenever a request is performed.
 // It should be added as first in the chain of middlewares.
 // Note that it doesn't catch any metrics by itself,
 // HTTP handlers are expected to add their own by calling AddObserver.
-func Measure() mux.MiddlewareFunc {
+func MeasureMiddleware() mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			t := StartTimer()
 			Logger.Log().Debugf("timer %p started", t)
 			rc := r.Clone(context.WithValue(r.Context(), timerContextKey, t))
+			defer func() {
+				t.Stop()
+				Logger.Log().Debugf("timer %p stopped (%.6fs)", t, t.Duration)
+			}()
+
 			next.ServeHTTP(w, rc)
-			t.Stop()
-			Logger.Log().Debugf("timer %p stopped (%.6fs)", t, t.Duration)
 		})
 	}
 }
@@ -34,7 +37,7 @@ func Measure() mux.MiddlewareFunc {
 func AddObserver(r *http.Request, o prometheus.Observer) error {
 	v := r.Context().Value(timerContextKey)
 	if v == nil {
-		return errors.Err("metrics.Measure middleware is required")
+		return errors.Err("metrics.MeasureMiddleware middleware is required")
 	}
 	t := v.(*Timer)
 	t.AddObserver(o)
@@ -42,7 +45,7 @@ func AddObserver(r *http.Request, o prometheus.Observer) error {
 }
 
 // GetDuration returns current duration of the request in seconds.
-// Returns a negative value when Measure middleware is not present.
+// Returns a negative value when MeasureMiddleware middleware is not present.
 func GetDuration(r *http.Request) float64 {
 	v := r.Context().Value(timerContextKey)
 	if v == nil {

--- a/internal/metrics/middleware.go
+++ b/internal/metrics/middleware.go
@@ -1,0 +1,38 @@
+package metrics
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/lbryio/lbrytv/internal/errors"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type key int
+
+const timerContextKey key = iota
+
+// Chain chains multiple middleware together
+func Measure() mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t := StartTimer()
+			Logger.Log().Debugf("timer %p started", t)
+			rc := r.Clone(context.WithValue(r.Context(), timerContextKey, t))
+			next.ServeHTTP(w, rc)
+			t.Stop()
+			Logger.Log().Debugf("timer %p stopped (%.6fs)", t, t.Duration)
+		})
+	}
+}
+
+func AddObserver(r *http.Request, o prometheus.Observer) error {
+	v := r.Context().Value(timerContextKey)
+	if v == nil {
+		return errors.Err("metrics.Measure middleware is required")
+	}
+	t := v.(*Timer)
+	t.AddObserver(o)
+	return nil
+}

--- a/internal/metrics/middleware_test.go
+++ b/internal/metrics/middleware_test.go
@@ -29,7 +29,7 @@ func waitingMiddleware() mux.MiddlewareFunc {
 	}
 }
 
-func TestMeasure(t *testing.T) {
+func TestMeasureMiddleware(t *testing.T) {
 	v := float64(0)
 	o := fakeObserver{&v}
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -43,7 +43,7 @@ func TestMeasure(t *testing.T) {
 	require.NoError(t, err)
 	rr := httptest.NewRecorder()
 	assert.NotPanics(t, func() {
-		middleware.Apply(Measure(), handler).ServeHTTP(rr, r)
+		middleware.Apply(MeasureMiddleware(), handler).ServeHTTP(rr, r)
 	})
 
 	res := rr.Result()
@@ -51,7 +51,7 @@ func TestMeasure(t *testing.T) {
 	assert.Greater(t, *o.value, float64(0.001))
 }
 
-func TestMeasureExtraMiddleware(t *testing.T) {
+func TestMeasureMiddlewareExtraMiddleware(t *testing.T) {
 	v := float64(0)
 	o := fakeObserver{&v}
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -65,7 +65,7 @@ func TestMeasureExtraMiddleware(t *testing.T) {
 	require.NoError(t, err)
 	rr := httptest.NewRecorder()
 	assert.NotPanics(t, func() {
-		middleware.Apply(middleware.Chain(Measure(), waitingMiddleware()), handler).ServeHTTP(rr, r)
+		middleware.Apply(middleware.Chain(MeasureMiddleware(), waitingMiddleware()), handler).ServeHTTP(rr, r)
 	})
 
 	res := rr.Result()
@@ -73,12 +73,35 @@ func TestMeasureExtraMiddleware(t *testing.T) {
 	assert.Greater(t, *o.value, float64(0.015))
 }
 
+func TestMeasureMiddlewarePanic(t *testing.T) {
+	v := float64(0)
+	o := fakeObserver{&v}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		time.Sleep(10 * time.Millisecond)
+		err := AddObserver(r, o)
+		require.NoError(t, err)
+		panic("oh")
+	}
+
+	r, err := http.NewRequest("POST", "/", nil)
+	require.NoError(t, err)
+	rr := httptest.NewRecorder()
+	assert.PanicsWithValue(t, "oh", func() {
+		middleware.Apply(MeasureMiddleware(), handler).ServeHTTP(rr, r)
+	})
+
+	res := rr.Result()
+	assert.Equal(t, http.StatusForbidden, res.StatusCode)
+	assert.Greater(t, *o.value, float64(0.005))
+}
+
 func TestAddObserverMissingMiddleware(t *testing.T) {
 	v := float64(0)
 	o := fakeObserver{&v}
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		err := AddObserver(r, o)
-		require.EqualError(t, err, "metrics.Measure middleware is required")
+		require.EqualError(t, err, "metrics.MeasureMiddleware middleware is required")
 	}
 
 	r, err := http.NewRequest("POST", "/", nil)
@@ -100,7 +123,7 @@ func TestGetDuration(t *testing.T) {
 	require.NoError(t, err)
 	rr := httptest.NewRecorder()
 	assert.NotPanics(t, func() {
-		middleware.Apply(middleware.Chain(Measure(), waitingMiddleware()), handler).ServeHTTP(rr, r)
+		middleware.Apply(middleware.Chain(MeasureMiddleware(), waitingMiddleware()), handler).ServeHTTP(rr, r)
 	})
 }
 

--- a/internal/metrics/middleware_test.go
+++ b/internal/metrics/middleware_test.go
@@ -1,0 +1,39 @@
+package metrics
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/lbryio/lbrytv/internal/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type FakeObserver struct {
+	value *float64
+}
+
+func (o FakeObserver) Observe(v float64) {
+	*(o.value) += v
+}
+
+func TestMeasure(t *testing.T) {
+	v := float64(0)
+	o := FakeObserver{&v}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		time.Sleep(10 * time.Millisecond)
+		AddObserver(r, o)
+	}
+	r, err := http.NewRequest("POST", "/", nil)
+	require.NoError(t, err)
+	rr := httptest.NewRecorder()
+	assert.NotPanics(t, func() {
+		middleware.Apply(Measure(), handler).ServeHTTP(rr, r)
+	})
+	res := rr.Result()
+	assert.Equal(t, http.StatusForbidden, res.StatusCode)
+	assert.Greater(t, *o.value, float64(0.001))
+}

--- a/internal/metrics/middleware_test.go
+++ b/internal/metrics/middleware_test.go
@@ -6,34 +6,85 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/lbryio/lbrytv/internal/middleware"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-type FakeObserver struct {
+type fakeObserver struct {
 	value *float64
 }
 
-func (o FakeObserver) Observe(v float64) {
+func (o fakeObserver) Observe(v float64) {
 	*(o.value) += v
+}
+
+func waitingMiddleware() mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(10 * time.Millisecond)
+			next.ServeHTTP(w, r)
+		})
+	}
 }
 
 func TestMeasure(t *testing.T) {
 	v := float64(0)
-	o := FakeObserver{&v}
+	o := fakeObserver{&v}
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
 		time.Sleep(10 * time.Millisecond)
-		AddObserver(r, o)
+		err := AddObserver(r, o)
+		require.NoError(t, err)
 	}
+
 	r, err := http.NewRequest("POST", "/", nil)
 	require.NoError(t, err)
 	rr := httptest.NewRecorder()
 	assert.NotPanics(t, func() {
 		middleware.Apply(Measure(), handler).ServeHTTP(rr, r)
 	})
+
 	res := rr.Result()
 	assert.Equal(t, http.StatusForbidden, res.StatusCode)
 	assert.Greater(t, *o.value, float64(0.001))
+}
+
+func TestMeasureExtraMiddleware(t *testing.T) {
+	v := float64(0)
+	o := fakeObserver{&v}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		time.Sleep(10 * time.Millisecond)
+		err := AddObserver(r, o)
+		require.NoError(t, err)
+	}
+
+	r, err := http.NewRequest("POST", "/", nil)
+	require.NoError(t, err)
+	rr := httptest.NewRecorder()
+	assert.NotPanics(t, func() {
+		middleware.Apply(middleware.Chain(Measure(), waitingMiddleware()), handler).ServeHTTP(rr, r)
+	})
+
+	res := rr.Result()
+	assert.Equal(t, http.StatusForbidden, res.StatusCode)
+	assert.Greater(t, *o.value, float64(0.015))
+}
+
+func TestAddObserverMissingMiddleware(t *testing.T) {
+	v := float64(0)
+	o := fakeObserver{&v}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		err := AddObserver(r, o)
+		require.EqualError(t, err, "metrics.Measure middleware is required")
+	}
+
+	r, err := http.NewRequest("POST", "/", nil)
+	require.NoError(t, err)
+	rr := httptest.NewRecorder()
+	assert.NotPanics(t, func() {
+		middleware.Apply(waitingMiddleware(), handler).ServeHTTP(rr, r)
+	})
 }

--- a/internal/metrics/middleware_test.go
+++ b/internal/metrics/middleware_test.go
@@ -88,3 +88,33 @@ func TestAddObserverMissingMiddleware(t *testing.T) {
 		middleware.Apply(waitingMiddleware(), handler).ServeHTTP(rr, r)
 	})
 }
+
+func TestGetDuration(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(10 * time.Millisecond)
+		d := GetDuration(r)
+		assert.Greater(t, d, float64(0.005))
+	}
+
+	r, err := http.NewRequest("POST", "/", nil)
+	require.NoError(t, err)
+	rr := httptest.NewRecorder()
+	assert.NotPanics(t, func() {
+		middleware.Apply(middleware.Chain(Measure(), waitingMiddleware()), handler).ServeHTTP(rr, r)
+	})
+}
+
+func TestGetDurationNoMiddleware(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(10 * time.Millisecond)
+		d := GetDuration(r)
+		assert.Less(t, d, float64(0))
+	}
+
+	r, err := http.NewRequest("POST", "/", nil)
+	require.NoError(t, err)
+	rr := httptest.NewRecorder()
+	assert.NotPanics(t, func() {
+		middleware.Apply(middleware.Chain(waitingMiddleware()), handler).ServeHTTP(rr, r)
+	})
+}

--- a/internal/metrics/timer.go
+++ b/internal/metrics/timer.go
@@ -31,6 +31,13 @@ func (t *Timer) Stop() float64 {
 	return t.Duration
 }
 
+func (t *Timer) GetDuration() float64 {
+	if t.Duration == 0 {
+		return time.Since(t.Started).Seconds()
+	}
+	return t.Duration
+}
+
 func (t *Timer) String() string {
-	return fmt.Sprintf("%.2f", t.Duration)
+	return fmt.Sprintf("%.2f", t.GetDuration())
 }

--- a/internal/metrics/timer.go
+++ b/internal/metrics/timer.go
@@ -8,25 +8,24 @@ import (
 )
 
 type Timer struct {
-	Started  time.Time
-	Duration float64
-	hist     prometheus.Histogram
+	Started   time.Time
+	Duration  float64
+	observers []prometheus.Observer
 }
 
-func TimerStart() *Timer {
+func StartTimer() *Timer {
 	return &Timer{Started: time.Now()}
 }
 
-func (t *Timer) Observe(hist prometheus.Histogram) *Timer {
-	t.hist = hist
-	return t
+func (t *Timer) AddObserver(o prometheus.Observer) {
+	t.observers = append(t.observers, o)
 }
 
-func (t *Timer) Done() float64 {
+func (t *Timer) Stop() float64 {
 	if t.Duration == 0 {
 		t.Duration = time.Since(t.Started).Seconds()
-		if t.hist != nil {
-			t.hist.Observe(t.Duration)
+		for _, o := range t.observers {
+			o.Observe(t.Duration)
 		}
 	}
 	return t.Duration


### PR DESCRIPTION
This adds measuring middleware so we can measure duration for the whole lifecycle of HTTP request, including time spent in other middlewares.