### PR TITLE
Improvement: token cache

### DIFF
--- a/app/wallet/cache.go
+++ b/app/wallet/cache.go
@@ -1,0 +1,46 @@
+package wallet
+
+import (
+	"time"
+
+	"github.com/lbryio/lbrytv/internal/metrics"
+	"github.com/lbryio/lbrytv/internal/monitor"
+
+	gocache "github.com/patrickmn/go-cache"
+)
+
+var (
+	cacheLogger  = monitor.NewModuleLogger("cache")
+	currentCache *tokenCache
+)
+
+// tokenCache stores the cache in memory
+type tokenCache struct {
+	cache *gocache.Cache
+}
+
+func init() {
+	SetTokenCache(NewTokenCache(5 * time.Minute))
+}
+
+func NewTokenCache(timeout time.Duration) *tokenCache {
+	return &tokenCache{cache: gocache.New(timeout, 10*time.Minute)}
+}
+
+func SetTokenCache(c *tokenCache) {
+	currentCache = c
+}
+
+func (c *tokenCache) set(token string, userID int) {
+	c.cache.Set(token, userID, gocache.DefaultExpiration)
+}
+
+func (c *tokenCache) get(token string) int {
+	uid, ok := c.cache.Get(token)
+	if !ok {
+		metrics.AuthTokenCacheMisses.Inc()
+		return 0
+	}
+	metrics.AuthTokenCacheHits.Inc()
+	return uid.(int)
+}

--- a/app/wallet/cache.go
+++ b/app/wallet/cache.go
@@ -44,3 +44,7 @@ func (c *tokenCache) get(token string) int {
 	metrics.AuthTokenCacheHits.Inc()
 	return uid.(int)
 }
+
+func (c *tokenCache) flush() {
+	c.cache.Flush()
+}

--- a/app/wallet/wallet.go
+++ b/app/wallet/wallet.go
@@ -54,7 +54,7 @@ func GetUserWithSDKServer(rt *sdkrouter.Router, internalAPIHost, token, metaRemo
 	log.Data["has_email"] = remoteUser.HasVerifiedEmail
 	log.Debugf("user authenticated")
 
-	ctx, cancelFn := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancelFn := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelFn()
 
 	var localUser *models.User

--- a/apps/lbrytv/config/config.go
+++ b/apps/lbrytv/config/config.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	cfg "github.com/lbryio/lbrytv/config"
 	"github.com/lbryio/lbrytv/models"
@@ -144,4 +145,8 @@ func GetLbrynetXServer() string {
 
 func GetLbrynetXPercentage() int {
 	return Config.Viper.GetInt("LbrynetXPercentage")
+}
+
+func GetTokenCacheTimeout() time.Duration {
+	return Config.Viper.GetDuration("TokenCacheTimeout") * time.Second
 }

--- a/apps/lbrytv/config/config_test.go
+++ b/apps/lbrytv/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -25,4 +26,10 @@ func TestGetLbrynetServersNoDB(t *testing.T) {
 		len(Config.Viper.GetStringMapString(lbrynetServers)) > 0 {
 		t.Fatalf("Both %s and %s are set. This is a highlander situation...there can be only one.", deprecatedLbrynet, lbrynetServers)
 	}
+}
+
+func TestGetTokenCacheTimeout(t *testing.T) {
+	Config.Override("TokenCacheTimeout", 325)
+	defer Config.RestoreOverridden()
+	assert.Equal(t, 325*time.Second, GetTokenCacheTimeout())
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/lbryio/lbrytv-player/pkg/paid"
 	"github.com/lbryio/lbrytv/app/sdkrouter"
+	"github.com/lbryio/lbrytv/app/wallet"
 	"github.com/lbryio/lbrytv/apps/lbrytv/config"
 	"github.com/lbryio/lbrytv/server"
 
@@ -38,6 +39,8 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
+		c := wallet.NewTokenCache(config.GetTokenCacheTimeout())
+		wallet.SetTokenCache(c)
 
 		// ServeUntilShutdown is blocking, should be last
 		s.ServeUntilShutdown()

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/pelletier/go-toml v1.8.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.3.0
+	github.com/prometheus/client_model v0.1.0
 	github.com/rubenv/sql-migrate v0.0.0-20200429072036-ae26b214fa43
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/sirupsen/logrus v1.6.0


### PR DESCRIPTION
This is a simple in-memory user token cache that should drastically reduce CPM for internal-api auth calls.