### PR TITLE
Create a new GRPC client for each query

### DIFF
--- a/app/query/caller.go
+++ b/app/query/caller.go
@@ -74,32 +74,58 @@ type Caller struct {
 
 	Duration float64
 
-	client   jsonrpc.RPCClient
 	userID   int
 	endpoint string
 }
 
 func NewCaller(endpoint string, userID int) *Caller {
 	c := &Caller{
-		client: jsonrpc.NewClientWithOpts(endpoint, &jsonrpc.RPCClientOpts{
-			HTTPClient: &http.Client{
-				Timeout: sdkrouter.RPCTimeout,
-				Transport: &http.Transport{
-					Dial: (&net.Dialer{
-						Timeout:   120 * time.Second,
-						KeepAlive: 120 * time.Second,
-					}).Dial,
-					TLSHandshakeTimeout:   30 * time.Second,
-					ResponseHeaderTimeout: 600 * time.Second,
-					ExpectContinueTimeout: 1 * time.Second,
-				},
-			},
-		}),
 		endpoint: endpoint,
 		userID:   userID,
 	}
 	c.addDefaultHooks()
 	return c
+}
+
+func (c *Caller) NewRPCClient(timeInSecondstimeOut time.Duration) *jsonrpc.RPCClient {
+	client := jsonrpc.NewClientWithOpts(c.endpoint, &jsonrpc.RPCClientOpts{
+		HTTPClient: &http.Client{
+			Timeout: sdkrouter.RPCTimeout,
+			Transport: &http.Transport{
+				Dial: (&net.Dialer{
+					Timeout:   timeInSecondstimeOut,
+					KeepAlive: timeInSecondstimeOut,
+				}).Dial,
+				TLSHandshakeTimeout:   30 * time.Second,
+				ResponseHeaderTimeout: 600 * time.Second,
+				ExpectContinueTimeout: 1 * time.Second,
+			},
+		},
+	})
+	return &client
+}
+
+func (c *Caller) GetTimeSpanForJSONRPCMethod(method string) time.Duration {
+	var retVal time.Duration
+	switch method {
+	case "txo_spend":
+		retVal = time.Hour * 3
+		break
+	case "txo_list":
+		retVal = time.Minute * 10
+		break
+	case "transaction_list":
+		retVal = time.Minute * 10
+		break
+	default:
+		retVal = time.Minute * 2
+	}
+	return retVal
+}
+
+func (c *Caller) GetRPCClientForMethod(method string) *jsonrpc.RPCClient {
+	var client *jsonrpc.RPCClient = c.NewRPCClient(c.GetTimeSpanForJSONRPCMethod(method))
+	return client
 }
 
 // AddPreflightHook adds query preflight hook function,
@@ -201,7 +227,8 @@ func (c *Caller) SendQuery(q *Query) (*jsonrpc.RPCResponse, error) {
 
 	for i := 0; i < walletLoadRetries; i++ {
 		start := time.Now()
-		r, err = c.client.CallRaw(q.Request)
+		client := *c.GetRPCClientForMethod(q.Method())
+		r, err = client.CallRaw(q.Request)
 		c.Duration = time.Since(start).Seconds()
 
 		// Generally a HTTP transport failure (connect error etc)

--- a/app/query/caller.go
+++ b/app/query/caller.go
@@ -105,7 +105,7 @@ func (c *Caller) newRPCClient(timeInSecondstimeOut time.Duration) jsonrpc.RPCCli
 	return client
 }
 
-func (c *Caller) GetTimeSpanForJSONRPCMethod(method string) time.Duration {
+func (c *Caller) getTimeSpanForJSONRPCMethod(method string) time.Duration {
 	timeSpanMap := map[string]time.Duration{
 		"txo_spend":        time.Hour * 3,
 		"txo_list":         time.Minute * 10,
@@ -119,8 +119,8 @@ func (c *Caller) GetTimeSpanForJSONRPCMethod(method string) time.Duration {
 	return time.Minute * 2
 }
 
-func (c *Caller) GetRPCClientForMethod(method string) jsonrpc.RPCClient {
-	var client jsonrpc.RPCClient = c.newRPCClient(c.GetTimeSpanForJSONRPCMethod(method))
+func (c *Caller) getRPCClientForMethod(method string) jsonrpc.RPCClient {
+	var client jsonrpc.RPCClient = c.newRPCClient(c.getTimeSpanForJSONRPCMethod(method))
 	return client
 }
 
@@ -223,7 +223,7 @@ func (c *Caller) SendQuery(q *Query) (*jsonrpc.RPCResponse, error) {
 
 	for i := 0; i < walletLoadRetries; i++ {
 		start := time.Now()
-		client := c.GetRPCClientForMethod(q.Method())
+		client := c.getRPCClientForMethod(q.Method())
 		r, err = client.CallRaw(q.Request)
 		c.Duration = time.Since(start).Seconds()
 

--- a/app/query/caller_test.go
+++ b/app/query/caller_test.go
@@ -549,16 +549,16 @@ func TestGetTimeSpanForJSONRPCMethod(t *testing.T) {
 	threeHours := time.Hour * 3
 	tenMinutes := time.Minute * 10
 	twoMinutes := time.Minute * 2
-	duration := c.GetTimeSpanForJSONRPCMethod("txo_spend")
+	duration := c.getTimeSpanForJSONRPCMethod("txo_spend")
 	require.Equal(t, threeHours, duration)
 
-	duration = c.GetTimeSpanForJSONRPCMethod("txo_list")
+	duration = c.getTimeSpanForJSONRPCMethod("txo_list")
 	require.Equal(t, tenMinutes, duration)
 
-	duration = c.GetTimeSpanForJSONRPCMethod("transaction_list")
+	duration = c.getTimeSpanForJSONRPCMethod("transaction_list")
 	require.Equal(t, tenMinutes, duration)
 
-	duration = c.GetTimeSpanForJSONRPCMethod("Any_other_method")
+	duration = c.getTimeSpanForJSONRPCMethod("Any_other_method")
 	require.Equal(t, twoMinutes, duration)
 }
 

--- a/app/query/caller_test.go
+++ b/app/query/caller_test.go
@@ -543,6 +543,25 @@ func TestCaller_CallQueryWithRetry(t *testing.T) {
 	require.Nil(t, r.Error)
 }
 
+func TestGetTimeSpanForJSONRPCMethod(t *testing.T) {
+	addr := test.RandServerAddress(t)
+	c := NewCaller(addr, 1)
+	threeHours := time.Hour * 3
+	tenMinutes := time.Minute * 10
+	twoMinutes := time.Minute * 2
+	duration := c.GetTimeSpanForJSONRPCMethod("txo_spend")
+	require.Equal(t, threeHours, duration)
+
+	duration = c.GetTimeSpanForJSONRPCMethod("txo_list")
+	require.Equal(t, tenMinutes, duration)
+
+	duration = c.GetTimeSpanForJSONRPCMethod("transaction_list")
+	require.Equal(t, tenMinutes, duration)
+
+	duration = c.GetTimeSpanForJSONRPCMethod("Any_other_method")
+	require.Equal(t, twoMinutes, duration)
+}
+
 func TestCaller_DontReloadWalletAfterOtherErrors(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	walletID := sdkrouter.WalletID(rand.Intn(100))

--- a/server/server.go
+++ b/server/server.go
@@ -31,8 +31,9 @@ func NewServer(address string, sdkRouter *sdkrouter.Router) *Server {
 	api.InstallRoutes(r, sdkRouter)
 	r.Use(monitor.ErrorLoggingMiddleware)
 	r.Use(defaultHeadersMiddleware(map[string]string{
-		"Server":                      "api.lbry.tv",
-		"Access-Control-Allow-Origin": "*",
+		"Server":                       "api.lbry.tv",
+		"Access-Control-Allow-Origin":  "*",
+		"Access-Control-Allow-Headers": "content-type", // Needed this to get any request to work
 	}))
 
 	return &Server{


### PR DESCRIPTION
For issue [301](https://github.com/lbryio/lbrytv/issues/301), increase the http timeout for methods `txo_spend`, `txo_list` and `transaction_list`. This will create a new client for each call. GetTimeSpanForJSONRPCMethod will return a timeout duration for a given method. I set `txo_spend` to 3 hours, `txo_list` and `transaction_list` to 10 minutes. All other methods default to the original 2 minutes. 

I've tested the app working and jsonrpc methods returning. I don't know of a good way to test a long timeout however. 
