### PR TITLE
asynquery: defer SDK call until both file and form are ready

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,8 +24,10 @@ jobs:
           go-version: '1.26'
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           only-new-issues: true
       - id: govulncheck
         uses: golang/govulncheck-action@v1
+        with:
+          repo-checkout: 'false'

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -111,7 +111,7 @@ jobs:
             echo "::endgroup::"
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -124,7 +124,7 @@ jobs:
 
       - name: Build and push odysee-api docker image
         if: env.APP_NAME == 'api'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           context: .
@@ -151,7 +151,7 @@ jobs:
 
       - name: Build watchman docker image
         if: env.APP_NAME == 'watchman'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           context: apps/${{ env.APP_NAME }}/

--- a/app/asynquery/asynquery.go
+++ b/app/asynquery/asynquery.go
@@ -26,7 +26,18 @@ import (
 	"github.com/ybbus/jsonrpc/v2"
 )
 
-const FilePathParam = "file_path"
+const (
+	FilePathParam = "file_path"
+	// DeferParam, when set to true in the request params, creates the
+	// asynquery row with ready_to_run=false. The actual SDK call is deferred
+	// until a subsequent Call without DeferParam arrives (or, if the file
+	// upload had already completed, queued immediately at that point).
+	// This lets the frontend pre-create the asynqueries row at upload-start
+	// time so forklift's upload:done event always finds a matching row,
+	// while still allowing the user's final form data to land before the
+	// SDK call fires. The flag is stripped from params before the SDK call.
+	DeferParam = "_defer"
+)
 
 var (
 	sdkNetError    = errors.New("network level sdk error")
@@ -59,9 +70,10 @@ type Result struct {
 }
 
 type queryParams struct {
-	queryID  string
-	uploadID string
-	userID   int
+	queryID    string
+	uploadID   string
+	userID     int
+	readyToRun bool
 }
 
 func NewCallManager(redisOpts asynq.RedisConnOpt, db boil.Executor, logger logging.KVLogger) (*CallManager, error) {
@@ -104,9 +116,18 @@ func (m *CallManager) Call(userID int, req *jsonrpc.RPCRequest) (*models.Asynque
 	)
 	p := req.Params.(map[string]any)
 
+	// Strip the _defer flag (frontend-only, never sent to SDK).
+	deferRun := false
+	if v, hasDefer := p[DeferParam]; hasDefer {
+		if b, isBool := v.(bool); isBool {
+			deferRun = b
+		}
+		delete(p, DeferParam)
+	}
+
 	// Metadata-only update
 	if filePathParam, ok = p[FilePathParam]; !ok {
-		aq, err := m.createQueryRecord(queryParams{userID: userID}, req)
+		aq, err := m.createQueryRecord(queryParams{userID: userID, readyToRun: !deferRun}, req)
 		if err != nil {
 			m.logger.Warn("error adding query record", "err", err, "user_id", userID)
 			return nil, fmt.Errorf("error adding query record: %w", err)
@@ -132,19 +153,54 @@ func (m *CallManager) Call(userID int, req *jsonrpc.RPCRequest) (*models.Asynque
 	}
 
 	aq, err := m.getQueryRecord(context.TODO(), queryParams{userID: userID, uploadID: fileLoc.UploadID})
-	// If query record exists and is not failed, return it
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return nil, err
 	}
-	if err == nil && aq.Status != models.AsynqueryStatusFailed {
-		return aq, nil
+	if err == nil {
+		// Row exists. If still in Received state we treat this as a
+		// commit/update of an earlier deferred draft: overwrite Body with
+		// the latest params and, unless this call is itself deferred, mark
+		// the row ready to run. If forklift's upload:done already arrived
+		// (file_ready=true), queue the SDK call now so it doesn't sit idle.
+		if aq.Status == models.AsynqueryStatusReceived {
+			rb, mErr := json.Marshal(req)
+			if mErr != nil {
+				return nil, fmt.Errorf("error marshaling request: %w", mErr)
+			}
+			aq.Body = null.JSONFrom(rb)
+			if !deferRun {
+				aq.ReadyToRun = true
+			}
+			aq.UpdatedAt = null.TimeFrom(time.Now())
+			if _, uErr := aq.Update(m.db, boil.Infer()); uErr != nil {
+				m.logger.Warn("error updating query record", "err", uErr, "user_id", userID)
+				return nil, fmt.Errorf("error updating query record: %w", uErr)
+			}
+			if !deferRun && aq.FileReady {
+				if qErr := m.queue.SendRequest(tasks.AsynqueryIncomingQuery, tasks.AsynqueryIncomingQueryPayload{
+					QueryID: aq.ID,
+					UserID:  userID,
+				}, queue.WithRequestRetry(3)); qErr != nil {
+					m.logger.Warn("error queuing query", "err", qErr, "user_id", userID)
+					return nil, fmt.Errorf("error queuing query: %w", qErr)
+				}
+				m.logger.Info("query committed and queued", "id", aq.ID, "user_id", userID)
+			} else {
+				m.logger.Info("query updated", "id", aq.ID, "user_id", userID, "deferred", deferRun, "file_ready", aq.FileReady)
+			}
+			return aq, nil
+		}
+		if aq.Status != models.AsynqueryStatusFailed {
+			return aq, nil
+		}
+		// Failed: fall through and re-create.
 	}
-	aq, err = m.createQueryRecord(queryParams{userID: userID, uploadID: fileLoc.UploadID}, req)
+	aq, err = m.createQueryRecord(queryParams{userID: userID, uploadID: fileLoc.UploadID, readyToRun: !deferRun}, req)
 	if err != nil {
 		m.logger.Warn("error adding query record", "err", err, "user_id", userID)
 		return nil, fmt.Errorf("error adding query record: %w", err)
 	}
-	m.logger.Info("query added", "id", aq.ID, "user_id", userID, "upload_id", fileLoc.UploadID)
+	m.logger.Info("query added", "id", aq.ID, "user_id", userID, "upload_id", fileLoc.UploadID, "deferred", deferRun)
 
 	return aq, nil
 }
@@ -169,19 +225,29 @@ func (m *CallManager) HandleMerge(ctx context.Context, task *asynq.Task) error {
 		return err
 	}
 	meta := payload.Meta
-	patch := map[string]any{
-		"file_size": meta.Size,
-		"file_name": meta.FileName,
-		"file_hash": meta.Hash,
-		"sd_hash":   meta.SDHash,
+
+	// If the asynquery row is still a draft (ready_to_run=false) the
+	// frontend hasn't committed final params yet — stash the file metadata
+	// on the row and mark file_ready. The SDK call will be queued when
+	// Call() arrives with the final params.
+	if !aq.ReadyToRun {
+		metaJSON, mErr := json.Marshal(meta)
+		if mErr != nil {
+			log.Warn("error marshaling file meta", "err", mErr)
+			return mErr
+		}
+		aq.FileReady = true
+		aq.FileMeta = null.JSONFrom(metaJSON)
+		aq.UpdatedAt = null.TimeFrom(time.Now())
+		if _, uErr := aq.Update(m.db, boil.Infer()); uErr != nil {
+			log.Warn("error updating query record with file_ready", "err", uErr)
+			return uErr
+		}
+		log.Info("file_ready stored, awaiting commit", "id", aq.ID)
+		return nil
 	}
-	if meta.Width > 0 && meta.Height > 0 {
-		patch["width"] = meta.Width
-		patch["height"] = meta.Height
-	}
-	if meta.Duration > 0 {
-		patch["duration"] = meta.Duration
-	}
+
+	patch := buildPatchFromMeta(meta)
 	err = m.robustCall(logging.AddToContext(ctx, log), aq, patch)
 	if err != nil {
 		return err
@@ -208,7 +274,18 @@ func (m *CallManager) HandleQuery(ctx context.Context, task *asynq.Task) error {
 		log.Info("error getting query record", "err", err)
 		return err
 	}
-	err = m.robustCall(logging.AddToContext(ctx, log), aq, nil)
+
+	var patch map[string]any
+	if aq.FileMeta.Valid {
+		var meta tasks.UploadMeta
+		if uErr := json.Unmarshal(aq.FileMeta.JSON, &meta); uErr == nil {
+			patch = buildPatchFromMeta(meta)
+		} else {
+			log.Warn("error unmarshaling stored file meta", "err", uErr)
+		}
+	}
+
+	err = m.robustCall(logging.AddToContext(ctx, log), aq, patch)
 	if err != nil {
 		return err
 	}
@@ -306,8 +383,9 @@ func (m *CallManager) robustCall(ctx context.Context, aq *models.Asynquery, patc
 
 func (m *CallManager) createQueryRecord(params queryParams, request *jsonrpc.RPCRequest) (*models.Asynquery, error) {
 	q := models.Asynquery{
-		UserID: int(params.userID),
-		Status: models.AsynqueryStatusReceived,
+		UserID:     int(params.userID),
+		Status:     models.AsynqueryStatusReceived,
+		ReadyToRun: params.readyToRun,
 	}
 	if params.uploadID != "" {
 		q.UploadID = params.uploadID
@@ -319,6 +397,23 @@ func (m *CallManager) createQueryRecord(params queryParams, request *jsonrpc.RPC
 	q.ID = fmt.Sprintf("%x%v", md5.Sum(rb), time.Now().UnixMilli())
 	q.Body = null.JSONFrom(rb)
 	return &q, q.Insert(m.db, boil.Infer())
+}
+
+func buildPatchFromMeta(meta tasks.UploadMeta) map[string]any {
+	patch := map[string]any{
+		"file_size": meta.Size,
+		"file_name": meta.FileName,
+		"file_hash": meta.Hash,
+		"sd_hash":   meta.SDHash,
+	}
+	if meta.Width > 0 && meta.Height > 0 {
+		patch["width"] = meta.Width
+		patch["height"] = meta.Height
+	}
+	if meta.Duration > 0 {
+		patch["duration"] = meta.Duration
+	}
+	return patch
 }
 
 func (m *CallManager) getQueryRecord(ctx context.Context, params queryParams) (*models.Asynquery, error) {

--- a/app/asynquery/asynquery.go
+++ b/app/asynquery/asynquery.go
@@ -28,15 +28,7 @@ import (
 
 const (
 	FilePathParam = "file_path"
-	// DeferParam, when set to true in the request params, creates the
-	// asynquery row with ready_to_run=false. The actual SDK call is deferred
-	// until a subsequent Call without DeferParam arrives (or, if the file
-	// upload had already completed, queued immediately at that point).
-	// This lets the frontend pre-create the asynqueries row at upload-start
-	// time so forklift's upload:done event always finds a matching row,
-	// while still allowing the user's final form data to land before the
-	// SDK call fires. The flag is stripped from params before the SDK call.
-	DeferParam = "_defer"
+	DeferParam    = "_defer"
 )
 
 var (
@@ -48,7 +40,7 @@ var (
 )
 
 type CallManager struct {
-	db     boil.Executor
+	db     *sql.DB
 	logger logging.KVLogger
 	queue  *queue.Queue
 }
@@ -76,7 +68,7 @@ type queryParams struct {
 	readyToRun bool
 }
 
-func NewCallManager(redisOpts asynq.RedisConnOpt, db boil.Executor, logger logging.KVLogger) (*CallManager, error) {
+func NewCallManager(redisOpts asynq.RedisConnOpt, db *sql.DB, logger logging.KVLogger) (*CallManager, error) {
 	m := CallManager{
 		logger: logger,
 		db:     db,
@@ -94,7 +86,6 @@ func (m *CallManager) NewCaller(userID int) *Caller {
 	return &Caller{manager: m, userID: userID}
 }
 
-// Start launches asynchronous query handlers and blocks until stopped.
 func (m *CallManager) Start() error {
 	onceMetrics.Do(registerMetrics)
 	m.queue.AddHandler(tasks.ForkliftUploadDone, m.HandleMerge)
@@ -106,17 +97,9 @@ func (m *CallManager) Shutdown() {
 	m.queue.Shutdown()
 }
 
-// Call accepts JSON-RPC request for later asynchronous processing.
 func (m *CallManager) Call(userID int, req *jsonrpc.RPCRequest) (*models.Asynquery, error) {
-	var (
-		filePath      string
-		filePathParam any
-		fileLoc       *FileLocation
-		ok            bool
-	)
 	p := req.Params.(map[string]any)
 
-	// Strip the _defer flag (frontend-only, never sent to SDK).
 	deferRun := false
 	if v, hasDefer := p[DeferParam]; hasDefer {
 		if b, isBool := v.(bool); isBool {
@@ -125,14 +108,13 @@ func (m *CallManager) Call(userID int, req *jsonrpc.RPCRequest) (*models.Asynque
 		delete(p, DeferParam)
 	}
 
-	// Metadata-only update
-	if filePathParam, ok = p[FilePathParam]; !ok {
-		aq, err := m.createQueryRecord(queryParams{userID: userID, readyToRun: !deferRun}, req)
+	filePathParam, hasFilePath := p[FilePathParam]
+	if !hasFilePath {
+		aq, err := m.createQueryRecord(m.db, queryParams{userID: userID, readyToRun: true}, req)
 		if err != nil {
 			m.logger.Warn("error adding query record", "err", err, "user_id", userID)
 			return nil, fmt.Errorf("error adding query record: %w", err)
 		}
-		// Sending query for immediate processing
 		err = m.queue.SendRequest(tasks.AsynqueryIncomingQuery, tasks.AsynqueryIncomingQueryPayload{
 			QueryID: aq.ID,
 			UserID:  userID,
@@ -144,7 +126,8 @@ func (m *CallManager) Call(userID int, req *jsonrpc.RPCRequest) (*models.Asynque
 		m.logger.Info("query added and queued", "id", aq.ID, "user_id", userID)
 		return aq, nil
 	}
-	if filePath, ok = filePathParam.(string); !ok {
+	filePath, ok := filePathParam.(string)
+	if !ok {
 		return nil, errors.New("invalid file path")
 	}
 	fileLoc, err := parseFilePath(filePath)
@@ -152,60 +135,160 @@ func (m *CallManager) Call(userID int, req *jsonrpc.RPCRequest) (*models.Asynque
 		return nil, err
 	}
 
-	aq, err := m.getQueryRecord(context.TODO(), queryParams{userID: userID, uploadID: fileLoc.UploadID})
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+	aq, shouldEnqueue, err := m.callUploadTx(userID, fileLoc.UploadID, deferRun, req)
+	if err != nil {
 		return nil, err
 	}
-	if err == nil {
-		// Row exists. If still in Received state we treat this as a
-		// commit/update of an earlier deferred draft: overwrite Body with
-		// the latest params and, unless this call is itself deferred, mark
-		// the row ready to run. If forklift's upload:done already arrived
-		// (file_ready=true), queue the SDK call now so it doesn't sit idle.
-		if aq.Status == models.AsynqueryStatusReceived {
-			rb, mErr := json.Marshal(req)
-			if mErr != nil {
-				return nil, fmt.Errorf("error marshaling request: %w", mErr)
-			}
-			aq.Body = null.JSONFrom(rb)
-			if !deferRun {
-				aq.ReadyToRun = true
-			}
-			aq.UpdatedAt = null.TimeFrom(time.Now())
-			if _, uErr := aq.Update(m.db, boil.Infer()); uErr != nil {
-				m.logger.Warn("error updating query record", "err", uErr, "user_id", userID)
-				return nil, fmt.Errorf("error updating query record: %w", uErr)
-			}
-			if !deferRun && aq.FileReady {
-				if qErr := m.queue.SendRequest(tasks.AsynqueryIncomingQuery, tasks.AsynqueryIncomingQueryPayload{
-					QueryID: aq.ID,
-					UserID:  userID,
-				}, queue.WithRequestRetry(3)); qErr != nil {
-					m.logger.Warn("error queuing query", "err", qErr, "user_id", userID)
-					return nil, fmt.Errorf("error queuing query: %w", qErr)
-				}
-				m.logger.Info("query committed and queued", "id", aq.ID, "user_id", userID)
-			} else {
-				m.logger.Info("query updated", "id", aq.ID, "user_id", userID, "deferred", deferRun, "file_ready", aq.FileReady)
-			}
-			return aq, nil
-		}
-		if aq.Status != models.AsynqueryStatusFailed {
-			return aq, nil
-		}
-		// Failed: fall through and re-create.
-	}
-	aq, err = m.createQueryRecord(queryParams{userID: userID, uploadID: fileLoc.UploadID, readyToRun: !deferRun}, req)
-	if err != nil {
-		m.logger.Warn("error adding query record", "err", err, "user_id", userID)
-		return nil, fmt.Errorf("error adding query record: %w", err)
-	}
-	m.logger.Info("query added", "id", aq.ID, "user_id", userID, "upload_id", fileLoc.UploadID, "deferred", deferRun)
 
+	if shouldEnqueue {
+		qErr := m.queue.SendRequest(tasks.AsynqueryIncomingQuery, tasks.AsynqueryIncomingQueryPayload{
+			QueryID: aq.ID,
+			UserID:  userID,
+		}, queue.WithRequestRetry(3))
+		if qErr != nil {
+			CommitEnqueueFailed.Inc()
+			m.logger.Error("commit enqueue failed", "err", qErr, "id", aq.ID, "user_id", userID)
+			return nil, fmt.Errorf("error queuing query: %w", qErr)
+		}
+		m.logger.Info("query committed and queued", "id", aq.ID, "user_id", userID)
+	}
 	return aq, nil
 }
 
-// HandleMerge handles signals about completed uploads from forklift.
+func (m *CallManager) callUploadTx(userID int, uploadID string, deferRun bool, req *jsonrpc.RPCRequest) (*models.Asynquery, bool, error) {
+	if !deferRun {
+		CommitsTotal.Inc()
+	}
+
+	tx, err := m.db.Begin()
+	if err != nil {
+		return nil, false, fmt.Errorf("begin tx: %w", err)
+	}
+
+	_, err = models.Users(
+		models.UserWhere.ID.EQ(userID),
+		qm.For("UPDATE"),
+	).One(tx)
+	if err != nil {
+		txRollback(tx)
+		return nil, false, fmt.Errorf("locking user row: %w", err)
+	}
+
+	aq, err := models.Asynqueries(
+		models.AsynqueryWhere.UploadID.EQ(uploadID),
+		models.AsynqueryWhere.UserID.EQ(userID),
+		qm.OrderBy(models.AsynqueryColumns.CreatedAt+" DESC"),
+		qm.For("UPDATE"),
+	).One(tx)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		txRollback(tx)
+		return nil, false, fmt.Errorf("looking up asynquery: %w", err)
+	}
+
+	if errors.Is(err, sql.ErrNoRows) {
+		newAq, cErr := m.createQueryRecord(tx, queryParams{
+			userID:     userID,
+			uploadID:   uploadID,
+			readyToRun: !deferRun,
+		}, req)
+		if cErr != nil {
+			txRollback(tx)
+			m.logger.Warn("error adding query record", "err", cErr, "user_id", userID)
+			return nil, false, fmt.Errorf("error adding query record: %w", cErr)
+		}
+		cErr = tx.Commit()
+		if cErr != nil {
+			return nil, false, fmt.Errorf("commit tx: %w", cErr)
+		}
+		if deferRun {
+			DraftsCreated.Inc()
+			m.logger.Info("draft query added", "id", newAq.ID, "user_id", userID, "upload_id", uploadID)
+		} else {
+			m.logger.Info("query added", "id", newAq.ID, "user_id", userID, "upload_id", uploadID)
+		}
+		return newAq, false, nil
+	}
+
+	if deferRun {
+		cErr := tx.Commit()
+		if cErr != nil {
+			return nil, false, fmt.Errorf("commit tx: %w", cErr)
+		}
+		m.logger.Info("late defer is a no-op", "id", aq.ID, "user_id", userID, "status", aq.Status, "ready_to_run", aq.ReadyToRun)
+		return aq, false, nil
+	}
+
+	switch aq.Status {
+	case models.AsynqueryStatusReceived:
+		if aq.ReadyToRun {
+			cErr := tx.Commit()
+			if cErr != nil {
+				return nil, false, fmt.Errorf("commit tx: %w", cErr)
+			}
+			m.logger.Info("idempotent re-commit no-op", "id", aq.ID, "user_id", userID)
+			return aq, false, nil
+		}
+
+		rb, mErr := json.Marshal(req)
+		if mErr != nil {
+			txRollback(tx)
+			return nil, false, fmt.Errorf("error marshaling request: %w", mErr)
+		}
+		aq.Body = null.JSONFrom(rb)
+		aq.ReadyToRun = true
+		aq.UpdatedAt = null.TimeFrom(time.Now())
+		_, uErr := aq.Update(tx, boil.Whitelist(
+			models.AsynqueryColumns.Body,
+			models.AsynqueryColumns.ReadyToRun,
+			models.AsynqueryColumns.UpdatedAt,
+		))
+		if uErr != nil {
+			txRollback(tx)
+			m.logger.Warn("error updating query record", "err", uErr, "user_id", userID)
+			return nil, false, fmt.Errorf("error updating query record: %w", uErr)
+		}
+
+		shouldEnqueue := aq.FileReady
+		cErr := tx.Commit()
+		if cErr != nil {
+			return nil, false, fmt.Errorf("commit tx: %w", cErr)
+		}
+		if !shouldEnqueue {
+			m.logger.Info("query committed, awaiting forklift", "id", aq.ID, "user_id", userID)
+		}
+		return aq, shouldEnqueue, nil
+
+	case models.AsynqueryStatusFailed:
+		newAq, cErr := m.createQueryRecord(tx, queryParams{
+			userID:     userID,
+			uploadID:   uploadID,
+			readyToRun: true,
+		}, req)
+		if cErr != nil {
+			txRollback(tx)
+			m.logger.Warn("error adding query record", "err", cErr, "user_id", userID)
+			return nil, false, fmt.Errorf("error adding query record: %w", cErr)
+		}
+		cErr = tx.Commit()
+		if cErr != nil {
+			return nil, false, fmt.Errorf("commit tx: %w", cErr)
+		}
+		m.logger.Info("query added (after failed)", "id", newAq.ID, "user_id", userID, "upload_id", uploadID)
+		return newAq, false, nil
+
+	default:
+		cErr := tx.Commit()
+		if cErr != nil {
+			return nil, false, fmt.Errorf("commit tx: %w", cErr)
+		}
+		return aq, false, nil
+	}
+}
+
+func txRollback(tx *sql.Tx) {
+	_ = tx.Rollback()
+}
+
 func (m *CallManager) HandleMerge(ctx context.Context, task *asynq.Task) error {
 	if task.Type() != tasks.ForkliftUploadDone {
 		m.logger.Warn("cannot handle task", "type", task.Type())
@@ -219,43 +302,80 @@ func (m *CallManager) HandleMerge(ctx context.Context, task *asynq.Task) error {
 	log := logging.TracedLogger(m.logger, payload)
 	log.Debug("task received")
 
-	aq, err := m.getQueryRecord(ctx, queryParams{uploadID: payload.UploadID, userID: int(payload.UserID)})
+	aq, shouldFireSDK, err := m.handleMergeTx(payload, log)
 	if err != nil {
-		log.Info("error getting query record", "err", err)
 		return err
 	}
-	meta := payload.Meta
+	if !shouldFireSDK {
+		return nil
+	}
 
-	// If the asynquery row is still a draft (ready_to_run=false) the
-	// frontend hasn't committed final params yet — stash the file metadata
-	// on the row and mark file_ready. The SDK call will be queued when
-	// Call() arrives with the final params.
+	patch := buildPatchFromMeta(payload.Meta)
+	return m.robustCall(logging.AddToContext(ctx, log), aq, patch)
+}
+
+func (m *CallManager) handleMergeTx(payload tasks.ForkliftUploadDonePayload, log logging.KVLogger) (*models.Asynquery, bool, error) {
+	tx, err := m.db.Begin()
+	if err != nil {
+		return nil, false, fmt.Errorf("begin tx: %w", err)
+	}
+
+	aq, err := models.Asynqueries(
+		models.AsynqueryWhere.UploadID.EQ(payload.UploadID),
+		models.AsynqueryWhere.UserID.EQ(int(payload.UserID)),
+		qm.OrderBy(models.AsynqueryColumns.CreatedAt+" DESC"),
+		qm.For("UPDATE"),
+	).One(tx)
+	if err != nil {
+		txRollback(tx)
+		log.Info("error getting query record", "err", err)
+		return nil, false, err
+	}
+
 	if !aq.ReadyToRun {
-		metaJSON, mErr := json.Marshal(meta)
+		metaJSON, mErr := json.Marshal(payload.Meta)
 		if mErr != nil {
+			txRollback(tx)
 			log.Warn("error marshaling file meta", "err", mErr)
-			return mErr
+			return nil, false, mErr
 		}
 		aq.FileReady = true
 		aq.FileMeta = null.JSONFrom(metaJSON)
 		aq.UpdatedAt = null.TimeFrom(time.Now())
-		if _, uErr := aq.Update(m.db, boil.Infer()); uErr != nil {
+		_, uErr := aq.Update(tx, boil.Whitelist(
+			models.AsynqueryColumns.FileReady,
+			models.AsynqueryColumns.FileMeta,
+			models.AsynqueryColumns.UpdatedAt,
+		))
+		if uErr != nil {
+			txRollback(tx)
 			log.Warn("error updating query record with file_ready", "err", uErr)
-			return uErr
+			return nil, false, uErr
+		}
+		cErr := tx.Commit()
+		if cErr != nil {
+			return nil, false, fmt.Errorf("commit tx: %w", cErr)
 		}
 		log.Info("file_ready stored, awaiting commit", "id", aq.ID)
-		return nil
+		return aq, false, nil
 	}
 
-	patch := buildPatchFromMeta(meta)
-	err = m.robustCall(logging.AddToContext(ctx, log), aq, patch)
-	if err != nil {
-		return err
+	if aq.Status == models.AsynqueryStatusSucceeded {
+		cErr := tx.Commit()
+		if cErr != nil {
+			return nil, false, fmt.Errorf("commit tx: %w", cErr)
+		}
+		log.Debug("dropping forklift:upload:done for already-succeeded row", "id", aq.ID)
+		return aq, false, nil
 	}
-	return nil
+
+	cErr := tx.Commit()
+	if cErr != nil {
+		return nil, false, fmt.Errorf("commit tx: %w", cErr)
+	}
+	return aq, true, nil
 }
 
-// HandleQuery handles asynchronous queries without uploads associated.
 func (m *CallManager) HandleQuery(ctx context.Context, task *asynq.Task) error {
 	if task.Type() != tasks.AsynqueryIncomingQuery {
 		m.logger.Warn("cannot handle task", "type", task.Type())
@@ -278,11 +398,17 @@ func (m *CallManager) HandleQuery(ctx context.Context, task *asynq.Task) error {
 	var patch map[string]any
 	if aq.FileMeta.Valid {
 		var meta tasks.UploadMeta
-		if uErr := json.Unmarshal(aq.FileMeta.JSON, &meta); uErr == nil {
-			patch = buildPatchFromMeta(meta)
-		} else {
+		uErr := json.Unmarshal(aq.FileMeta.JSON, &meta)
+		if uErr != nil {
 			log.Warn("error unmarshaling stored file meta", "err", uErr)
+			fErr := m.finalizeQueryRecord(logging.AddToContext(ctx, log), aq.ID, nil, fmt.Sprintf("invalid stored file metadata: %v", uErr))
+			if fErr != nil {
+				log.Warn("failed to finalize asynquery record after meta unmarshal error", "err", fErr)
+				return fErr
+			}
+			return asynq.SkipRetry
 		}
+		patch = buildPatchFromMeta(meta)
 	}
 
 	err = m.robustCall(logging.AddToContext(ctx, log), aq, patch)
@@ -323,7 +449,6 @@ func (m *CallManager) robustCall(ctx context.Context, aq *models.Asynquery, patc
 		return asynq.SkipRetry
 	}
 
-	// Patch the original SDK request
 	pp, ok := request.Params.(map[string]any)
 	if !ok {
 		log.Info("cannot extract params from request")
@@ -381,7 +506,7 @@ func (m *CallManager) robustCall(ctx context.Context, aq *models.Asynquery, patc
 	return nil
 }
 
-func (m *CallManager) createQueryRecord(params queryParams, request *jsonrpc.RPCRequest) (*models.Asynquery, error) {
+func (m *CallManager) createQueryRecord(exec boil.Executor, params queryParams, request *jsonrpc.RPCRequest) (*models.Asynquery, error) {
 	q := models.Asynquery{
 		UserID:     int(params.userID),
 		Status:     models.AsynqueryStatusReceived,
@@ -396,7 +521,7 @@ func (m *CallManager) createQueryRecord(params queryParams, request *jsonrpc.RPC
 	}
 	q.ID = fmt.Sprintf("%x%v", md5.Sum(rb), time.Now().UnixMilli())
 	q.Body = null.JSONFrom(rb)
-	return &q, q.Insert(m.db, boil.Infer())
+	return &q, q.Insert(exec, boil.Greylist(models.AsynqueryColumns.ReadyToRun))
 }
 
 func buildPatchFromMeta(meta tasks.UploadMeta) map[string]any {
@@ -458,7 +583,7 @@ func (m *CallManager) finalizeQueryRecord(ctx context.Context, queryID string, r
 	q.Response = jr
 	q.Error = callErr
 
-	if response.Error != nil || callErr != "" {
+	if response == nil || response.Error != nil || callErr != "" {
 		q.Status = models.AsynqueryStatusFailed
 	} else {
 		q.Status = models.AsynqueryStatusSucceeded

--- a/app/asynquery/metrics.go
+++ b/app/asynquery/metrics.go
@@ -37,10 +37,23 @@ var (
 		Namespace: ns,
 		Name:      "queries_errored",
 	})
+	DraftsCreated = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: ns,
+		Name:      "drafts_created_total",
+	})
+	CommitsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: ns,
+		Name:      "commits_total",
+	})
+	CommitEnqueueFailed = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: ns,
+		Name:      "commit_enqueue_failed_total",
+	})
 )
 
 func registerMetrics() {
 	prometheus.MustRegister(
 		InternalErrors, QueriesSent, QueriesCompleted, QueriesFailed, QueriesErrored,
+		DraftsCreated, CommitsTotal, CommitEnqueueFailed,
 	)
 }

--- a/app/asynquery/routes.go
+++ b/app/asynquery/routes.go
@@ -3,6 +3,7 @@ package asynquery
 import (
 	"context"
 	"crypto"
+	"database/sql"
 	"errors"
 	"net/http"
 
@@ -11,12 +12,11 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/hibiken/asynq"
-	"github.com/volatiletech/sqlboiler/boil"
 )
 
 type Launcher struct {
 	requestsConnOpts asynq.RedisConnOpt
-	db               boil.Executor
+	db               *sql.DB
 	logger           logging.KVLogger
 	manager          *CallManager
 	privateKey       crypto.PrivateKey
@@ -32,7 +32,7 @@ func WithPrivateKey(privateKey crypto.PrivateKey) LauncherOption {
 	}
 }
 
-func WithDB(db boil.Executor) LauncherOption {
+func WithDB(db *sql.DB) LauncherOption {
 	return func(l *Launcher) {
 		l.db = db
 	}

--- a/internal/storage/migrations/0012_asynqueries_publish_race.sql
+++ b/internal/storage/migrations/0012_asynqueries_publish_race.sql
@@ -1,0 +1,13 @@
+-- +migrate Up
+-- +migrate StatementBegin
+ALTER TABLE asynqueries ADD COLUMN ready_to_run boolean NOT NULL DEFAULT true;
+ALTER TABLE asynqueries ADD COLUMN file_ready boolean NOT NULL DEFAULT false;
+ALTER TABLE asynqueries ADD COLUMN file_meta jsonb;
+-- +migrate StatementEnd
+
+-- +migrate Down
+-- +migrate StatementBegin
+ALTER TABLE asynqueries DROP COLUMN ready_to_run;
+ALTER TABLE asynqueries DROP COLUMN file_ready;
+ALTER TABLE asynqueries DROP COLUMN file_meta;
+-- +migrate StatementEnd

--- a/models/asynqueries.go
+++ b/models/asynqueries.go
@@ -23,40 +23,49 @@ import (
 
 // Asynquery is an object representing the database table.
 type Asynquery struct {
-	ID        string    `boil:"id" json:"id" toml:"id" yaml:"id"`
-	UserID    int       `boil:"user_id" json:"user_id" toml:"user_id" yaml:"user_id"`
-	CreatedAt time.Time `boil:"created_at" json:"created_at" toml:"created_at" yaml:"created_at"`
-	UpdatedAt null.Time `boil:"updated_at" json:"updated_at,omitempty" toml:"updated_at" yaml:"updated_at,omitempty"`
-	Status    string    `boil:"status" json:"status" toml:"status" yaml:"status"`
-	Error     string    `boil:"error" json:"error" toml:"error" yaml:"error"`
-	UploadID  string    `boil:"upload_id" json:"upload_id" toml:"upload_id" yaml:"upload_id"`
-	Body      null.JSON `boil:"body" json:"body,omitempty" toml:"body" yaml:"body,omitempty"`
-	Response  null.JSON `boil:"response" json:"response,omitempty" toml:"response" yaml:"response,omitempty"`
+	ID         string    `boil:"id" json:"id" toml:"id" yaml:"id"`
+	UserID     int       `boil:"user_id" json:"user_id" toml:"user_id" yaml:"user_id"`
+	CreatedAt  time.Time `boil:"created_at" json:"created_at" toml:"created_at" yaml:"created_at"`
+	UpdatedAt  null.Time `boil:"updated_at" json:"updated_at,omitempty" toml:"updated_at" yaml:"updated_at,omitempty"`
+	Status     string    `boil:"status" json:"status" toml:"status" yaml:"status"`
+	Error      string    `boil:"error" json:"error" toml:"error" yaml:"error"`
+	UploadID   string    `boil:"upload_id" json:"upload_id" toml:"upload_id" yaml:"upload_id"`
+	Body       null.JSON `boil:"body" json:"body,omitempty" toml:"body" yaml:"body,omitempty"`
+	Response   null.JSON `boil:"response" json:"response,omitempty" toml:"response" yaml:"response,omitempty"`
+	ReadyToRun bool      `boil:"ready_to_run" json:"ready_to_run" toml:"ready_to_run" yaml:"ready_to_run"`
+	FileReady  bool      `boil:"file_ready" json:"file_ready" toml:"file_ready" yaml:"file_ready"`
+	FileMeta   null.JSON `boil:"file_meta" json:"file_meta,omitempty" toml:"file_meta" yaml:"file_meta,omitempty"`
 
 	R *asynqueryR `boil:"-" json:"-" toml:"-" yaml:"-"`
 	L asynqueryL  `boil:"-" json:"-" toml:"-" yaml:"-"`
 }
 
 var AsynqueryColumns = struct {
-	ID        string
-	UserID    string
-	CreatedAt string
-	UpdatedAt string
-	Status    string
-	Error     string
-	UploadID  string
-	Body      string
-	Response  string
+	ID         string
+	UserID     string
+	CreatedAt  string
+	UpdatedAt  string
+	Status     string
+	Error      string
+	UploadID   string
+	Body       string
+	Response   string
+	ReadyToRun string
+	FileReady  string
+	FileMeta   string
 }{
-	ID:        "id",
-	UserID:    "user_id",
-	CreatedAt: "created_at",
-	UpdatedAt: "updated_at",
-	Status:    "status",
-	Error:     "error",
-	UploadID:  "upload_id",
-	Body:      "body",
-	Response:  "response",
+	ID:         "id",
+	UserID:     "user_id",
+	CreatedAt:  "created_at",
+	UpdatedAt:  "updated_at",
+	Status:     "status",
+	Error:      "error",
+	UploadID:   "upload_id",
+	Body:       "body",
+	Response:   "response",
+	ReadyToRun: "ready_to_run",
+	FileReady:  "file_ready",
+	FileMeta:   "file_meta",
 }
 
 // Generated where
@@ -189,9 +198,9 @@ func (*asynqueryR) NewStruct() *asynqueryR {
 type asynqueryL struct{}
 
 var (
-	asynqueryAllColumns            = []string{"id", "user_id", "created_at", "updated_at", "status", "error", "upload_id", "body", "response"}
-	asynqueryColumnsWithoutDefault = []string{"id", "user_id", "updated_at", "status", "error", "upload_id", "body", "response"}
-	asynqueryColumnsWithDefault    = []string{"created_at"}
+	asynqueryAllColumns            = []string{"id", "user_id", "created_at", "updated_at", "status", "error", "upload_id", "body", "response", "ready_to_run", "file_ready", "file_meta"}
+	asynqueryColumnsWithoutDefault = []string{"id", "user_id", "updated_at", "status", "error", "upload_id", "body", "response", "file_meta"}
+	asynqueryColumnsWithDefault    = []string{"created_at", "ready_to_run", "file_ready"}
 	asynqueryPrimaryKeyColumns     = []string{"id"}
 )
 

--- a/models/asynqueries.go
+++ b/models/asynqueries.go
@@ -155,26 +155,41 @@ func (w whereHelpernull_JSON) GTE(x null.JSON) qm.QueryMod {
 	return qmhelper.Where(w.field, qmhelper.GTE, x)
 }
 
+type whereHelperbool struct{ field string }
+
+func (w whereHelperbool) EQ(x bool) qm.QueryMod  { return qmhelper.Where(w.field, qmhelper.EQ, x) }
+func (w whereHelperbool) NEQ(x bool) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.NEQ, x) }
+func (w whereHelperbool) LT(x bool) qm.QueryMod  { return qmhelper.Where(w.field, qmhelper.LT, x) }
+func (w whereHelperbool) LTE(x bool) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.LTE, x) }
+func (w whereHelperbool) GT(x bool) qm.QueryMod  { return qmhelper.Where(w.field, qmhelper.GT, x) }
+func (w whereHelperbool) GTE(x bool) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.GTE, x) }
+
 var AsynqueryWhere = struct {
-	ID        whereHelperstring
-	UserID    whereHelperint
-	CreatedAt whereHelpertime_Time
-	UpdatedAt whereHelpernull_Time
-	Status    whereHelperstring
-	Error     whereHelperstring
-	UploadID  whereHelperstring
-	Body      whereHelpernull_JSON
-	Response  whereHelpernull_JSON
+	ID         whereHelperstring
+	UserID     whereHelperint
+	CreatedAt  whereHelpertime_Time
+	UpdatedAt  whereHelpernull_Time
+	Status     whereHelperstring
+	Error      whereHelperstring
+	UploadID   whereHelperstring
+	Body       whereHelpernull_JSON
+	Response   whereHelpernull_JSON
+	ReadyToRun whereHelperbool
+	FileReady  whereHelperbool
+	FileMeta   whereHelpernull_JSON
 }{
-	ID:        whereHelperstring{field: "\"asynqueries\".\"id\""},
-	UserID:    whereHelperint{field: "\"asynqueries\".\"user_id\""},
-	CreatedAt: whereHelpertime_Time{field: "\"asynqueries\".\"created_at\""},
-	UpdatedAt: whereHelpernull_Time{field: "\"asynqueries\".\"updated_at\""},
-	Status:    whereHelperstring{field: "\"asynqueries\".\"status\""},
-	Error:     whereHelperstring{field: "\"asynqueries\".\"error\""},
-	UploadID:  whereHelperstring{field: "\"asynqueries\".\"upload_id\""},
-	Body:      whereHelpernull_JSON{field: "\"asynqueries\".\"body\""},
-	Response:  whereHelpernull_JSON{field: "\"asynqueries\".\"response\""},
+	ID:         whereHelperstring{field: "\"asynqueries\".\"id\""},
+	UserID:     whereHelperint{field: "\"asynqueries\".\"user_id\""},
+	CreatedAt:  whereHelpertime_Time{field: "\"asynqueries\".\"created_at\""},
+	UpdatedAt:  whereHelpernull_Time{field: "\"asynqueries\".\"updated_at\""},
+	Status:     whereHelperstring{field: "\"asynqueries\".\"status\""},
+	Error:      whereHelperstring{field: "\"asynqueries\".\"error\""},
+	UploadID:   whereHelperstring{field: "\"asynqueries\".\"upload_id\""},
+	Body:       whereHelpernull_JSON{field: "\"asynqueries\".\"body\""},
+	Response:   whereHelpernull_JSON{field: "\"asynqueries\".\"response\""},
+	ReadyToRun: whereHelperbool{field: "\"asynqueries\".\"ready_to_run\""},
+	FileReady:  whereHelperbool{field: "\"asynqueries\".\"file_ready\""},
+	FileMeta:   whereHelpernull_JSON{field: "\"asynqueries\".\"file_meta\""},
 }
 
 // AsynqueryRels is where relationship names are stored.

--- a/models/lbrynet_servers.go
+++ b/models/lbrynet_servers.go
@@ -54,15 +54,6 @@ var LbrynetServerColumns = struct {
 
 // Generated where
 
-type whereHelperbool struct{ field string }
-
-func (w whereHelperbool) EQ(x bool) qm.QueryMod  { return qmhelper.Where(w.field, qmhelper.EQ, x) }
-func (w whereHelperbool) NEQ(x bool) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.NEQ, x) }
-func (w whereHelperbool) LT(x bool) qm.QueryMod  { return qmhelper.Where(w.field, qmhelper.LT, x) }
-func (w whereHelperbool) LTE(x bool) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.LTE, x) }
-func (w whereHelperbool) GT(x bool) qm.QueryMod  { return qmhelper.Where(w.field, qmhelper.GT, x) }
-func (w whereHelperbool) GTE(x bool) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.GTE, x) }
-
 var LbrynetServerWhere = struct {
 	ID        whereHelperint
 	Name      whereHelperstring


### PR DESCRIPTION
## What this fixes

A race in the publish flow that strands ~7% of uploads. The frontend kicks off the TUS upload as soon as the user picks a file, but the backend only creates the `asynqueries` row when the user clicks Publish. On a fast upload, forklift's `upload:done` fires before the row exists, retries 15× over ~150s, gets archived, and the eventual row sits at `received` forever with no task to drive it.

## How

Cooperative two-stage commit. The frontend sends `_defer: true` on its early createClaim, creating a draft row. When the user clicks Publish, the same `stream_create` POST without `_defer` commits the row's body. Whichever side arrives second — forklift's upload-done or the user's commit — fires the SDK call. Defaults preserve existing behavior for any client that doesn't opt in.

Three new columns on `asynqueries`:
- `ready_to_run` — false on a draft, true after Publish
- `file_ready` — true after upload-done
- `file_meta` — metadata stashed by forklift when it arrives first

## Concurrency safeguards

- Concurrent publishes for the same user are serialized through a DB lock on the user row before any asynquery touch
- Form-commit and upload-done coordinate under a row-level lock so exactly one of them fires the SDK
- Upload-done events for already-succeeded publishes are dropped to avoid re-publishing on chain
- Double-clicked Publish is idempotent: the second click returns the existing row as-is
- Failed background-task kickoff after commit returns an error to the caller and increments `commit_enqueue_failed_total` (see Open question)
- Corrupt stored file metadata marks the publish failed and surfaces the error to the user
- Draft inserts explicitly carry the draft flag so the DB default doesn't override it
- Each writer touches only its own columns so concurrent updates can't clobber each other
- Finalizing after a network error tolerates a nil response

New counters: `drafts_created_total`, `commits_total`, `commit_enqueue_failed_total` — alert on the last.

## Open question

The "failed enqueue after commit" path assumes the frontend's failure-retry behavior is to re-upload (which produces a fresh `upload_id` and a fresh draft row). If the frontend instead re-POSTs the same Publish against the same upload, the idempotent re-commit returns the existing row as a no-op without re-enqueuing, and the user stays stuck. Worth confirming before merge; if needed we can add a small recovery path.

## Migration

Migration 0012 adds the three new columns. Model file is generated via `make models` against the migrated schema.

## CI

Two unrelated workflow fixes:
- `golang/govulncheck-action` is invoked with `repo-checkout: false` so it doesn't conflict with the workflow's top-level checkout.
- `golangci-lint-action`, `docker/build-push-action`, and `docker/login-action` updated to Node 24 versions.

A `govulncheck` advisory still fires on `github.com/docker/docker` via `ory/dockertest` (init-only reachability in test-only code, no upstream fix available). Left as-is for now.